### PR TITLE
Dependency graph for configuration items

### DIFF
--- a/pkg/pillar/depgraph/depgraph.go
+++ b/pkg/pillar/depgraph/depgraph.go
@@ -1,0 +1,861 @@
+// Copyright (c) 2021 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package depgraph
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+)
+
+const (
+	// Forward-slash is used as a separator to build a path of nested clusters
+	// as a string.
+	clusterPathSep = "/"
+)
+
+type depGraph struct {
+	*clusterSelector
+	log *base.LogObject
+
+	configurators map[string]Configurator // key = item type
+
+	// All 3 maps below use item name as the key.
+	nodes map[string]*node
+	// Note that edges are kept even if the destination is missing.
+	// If node from which an edge originates is removed, however,
+	// then the edge is removed as well.
+	outgoingEdges map[string]edges
+	incomingEdges map[string]edges // inverted edges
+
+	clusters map[string]*clusterInfo // key = cluster path
+
+	// Nodes sorted lexicographically by clusterPath, then item Name.
+	sortedNodes []*node
+
+	plannedChanges plannedChanges
+	syncIndex      int64 // to identify and log each run of Sync()
+}
+
+type node struct {
+	name        string
+	value       Item // never nil - nodes of deleted items are removed from the graph
+	newValue    Item // used temporarily during Sync()
+	needSync    bool // intended state = .newValue, actual state = .value
+	state       ItemState
+	lastOp      Operation
+	lastErr     error
+	clusterPath string
+}
+
+func (node *node) created() bool {
+	// Note: node has state unknown if it was just added to the graph.
+	return node.state != ItemStateUnknown &&
+		node.state != ItemStatePending &&
+		(node.state != ItemStateDeleting || node.lastOp != OperationDelete) &&
+		(node.state != ItemStateRecreating || node.lastOp != OperationDelete) &&
+		!node.failedToCreate()
+}
+
+func (node *node) failedToCreate() bool {
+	return node.state == ItemStateFailure &&
+		(node.lastOp == OperationCreate || node.lastOp == OperationRecreate)
+}
+
+func (node *node) getNewValue() Item {
+	if node.needSync {
+		return node.newValue
+	}
+	return node.value
+}
+
+type edge struct {
+	// Edges always originate from nodes.
+	// This field is therefore always defined.
+	fromNode string // node.name
+
+	// Currently edges always point to nodes, but later
+	// we could add dependencies on e.g. clusters and instead of toNode
+	// there would be toCluster defined.
+	toNode string // node.name
+
+	// Dependency represented by this edge.
+	dependency Dependency
+}
+
+type edges []*edge
+
+func remove(edges edges, edgeIndex int) edges {
+	edges[edgeIndex] = edges[len(edges)-1]
+	edges[len(edges)-1] = nil
+	edges = edges[:len(edges)-1]
+	return edges
+}
+
+type clusterInfo struct {
+	name        string
+	path        string
+	nodeCount   int // includes nodes from sub-clusters
+	description string
+}
+
+func parentClusterPath(subClusterPath string) string {
+	pathPrefix := subClusterPath[:len(subClusterPath)-len(clusterPathSep)]
+	index := strings.LastIndex(pathPrefix, clusterPathSep)
+	if index == -1 {
+		return ""
+	}
+	return pathPrefix[:index+1]
+}
+
+func clusterNameFromPath(clusterPath string) string {
+	parentPath := parentClusterPath(clusterPath)
+	return clusterPath[len(parentPath) : len(clusterPath)-len(clusterPathSep)]
+}
+
+// NewDepGraph returns a new instance of the dependency graph.
+func NewDepGraph(log *base.LogObject) DepGraph {
+	// top-level cluster has empty name and represents the graph as a whole
+	topLevelClusterPath := clusterPathSep
+	g := &depGraph{
+		clusterSelector: &clusterSelector{
+			clusterPath: topLevelClusterPath,
+		},
+		log:           log,
+		configurators: make(map[string]Configurator),
+		nodes:         make(map[string]*node),
+		outgoingEdges: make(map[string]edges),
+		incomingEdges: make(map[string]edges),
+		clusters: map[string]*clusterInfo{
+			topLevelClusterPath: {
+				path: topLevelClusterPath,
+			},
+		},
+	}
+	g.clearPlannedChanges()
+	g.clusterSelector.graph = g
+	return g
+}
+
+// RegisterConfigurator makes association between a Configurator and items
+// of the given type. When changes are made to the intended configuration for
+// these items, DepGraph will know where to look for the implementation
+// of the Create, Modify and Delete operations and will call them from Sync().
+// Additionally, Configurator is used by DepGraph to learn the dependencies of an item.
+func (g *depGraph) RegisterConfigurator(configurator Configurator, itemType string) error {
+	_, duplicate := g.configurators[itemType]
+	if duplicate {
+		err := fmt.Errorf("multiple configurators registered for item type: %s",
+			itemType)
+		g.log.Error(err)
+		return err
+	}
+	g.configurators[itemType] = configurator
+	return nil
+}
+
+type syncMetrics struct {
+	createCount int
+	deleteCount int
+	modifyCount int
+}
+
+// Sync performs all Create/Modify/Delete operations (provided by Configurators)
+// to get the (new) intended and the actual (previous intended) state in-sync.
+// Currently, it is assumed that the actual state is the same as the intended state
+// of the last Sync() and the new intended state additionally contains all the changes
+// that were made to the graph since.
+func (g *depGraph) Sync(ctx context.Context) (err error) {
+	if len(g.plannedChanges.clusters) == 0 &&
+		len(g.plannedChanges.items) == 0 {
+		// nothing to do
+		return nil
+	}
+
+	defer g.clearPlannedChanges()
+	syncIndex := g.syncIndex
+	g.syncIndex++
+
+	// 1. Sync cluster info
+	g.syncClusterInfo()
+
+	// 2. Sync item changes
+	metrics, errs := g.syncItems(ctx)
+
+	// 3. GC unused clusters
+	for clusterPath, cluster := range g.clusters {
+		if cluster.nodeCount == 0 {
+			g.log.Noticef("Removing unused graph cluster %s", cluster.path)
+			delete(g.clusters, clusterPath)
+		}
+	}
+
+	// 4. Log summary info
+	g.log.Noticef("Executed DepGraph.Sync() #%d: %dx Create, %dx Modify, %dx Delete; %d errors",
+		syncIndex, metrics.createCount, metrics.modifyCount, metrics.deleteCount, len(errs))
+	err = nil
+	if len(errs) > 0 {
+		var errMsgs []string
+		for _, err := range errs {
+			errMsgs = append(errMsgs, err.Error())
+		}
+		err = errors.New(strings.Join(errMsgs, "; "))
+	}
+	return err
+}
+
+// Sync all pending item changes.
+// Create/Modify/Delete operations are performed in two stages:
+//   1. First all Delete + Modify operations are executed (incl. the first half of the Recreate).
+//   2. Next all (Re)Create operations are carried out.
+// In both cases the nodes are traversed using DFS and the operations are executed
+// in the forward or reverse topological order with respect to the dependencies.
+// In the first stage, Delete/Modify operations are run in the DFS post-order, while
+// in the seconds stage Create operations are lined up in the DFS pre-order.
+// A simple stack structure is used to remember nodes which are being visited
+// (recursion is intentionally avoided). In the first stage, each node is inserted into
+// the stack only a constant number of times, whereas in the second stage a node
+// could be added into the stack once for every outgoing edge to re-check dependencies
+// of a pending item. Cumulatively, this gives us a time complexity O(V + E), where V
+// represents the set of nodes and E the set of edges. In practise, the number of dependencies
+// a configuration item will have is constant, hence the complexity can be simplified to O(V).
+// The sparsity of the graph is the reason why DFS was selected over BFS.
+func (g *depGraph) syncItems(ctx context.Context) (metrics syncMetrics, errs []error) {
+	var err error
+	// Initialize stacks, node.newValue and node.needSync.
+	// Also add new nodes into the graph (with ItemStateUnknown for now).
+	stage1Stack := newStack()
+	stage2Stack := newStack()
+	for _, itemChange := range g.plannedChanges.items {
+		itemName := itemChange.itemName
+		newValue := itemChange.newValue
+		newClusterPath := itemChange.clusterPath
+		node, exists := g.nodes[itemName]
+		if !exists && newValue == nil {
+			// delete of non-existing item is NOOP
+			continue
+		}
+		if exists {
+			if newValue != nil && node.value.External() != newValue.External() {
+				panic(fmt.Sprintf("External-mismatch for item %s", itemName))
+			}
+			if newValue != nil && node.value.Type() != newValue.Type() {
+				panic(fmt.Sprintf("Type-mismatch for item %s", itemName))
+			}
+			node.newValue = newValue
+			node.needSync = true
+			g.updateNodeClusterPath(itemName, newClusterPath)
+		} else {
+			var deps []Dependency
+			if !newValue.External() {
+				deps = g.getConfigurator(newValue.Type()).DependsOn(newValue)
+				validateDeps(deps)
+			}
+			g.addNewNode(itemName, newClusterPath, newValue, deps)
+		}
+		stage1Stack.push(stackedItem{itemName: itemName})
+	}
+
+	// Stage 1: Run Delete + Modify operations
+	// From every node to be deleted, run DFS and delete all nodes that
+	// depend on it in the DFS *post-order*.
+	// At this stage, a node state may change only in this direction:
+	//  Created -> Deleting/Recreating/Modifying -> Failure/Pending/<Deleted>
+	// Only at the transition from Created to Deleting/Recreating/Modifying
+	// we trigger DFS from the node.
+	for !stage1Stack.isEmpty() {
+		item, _ := stage1Stack.pop()
+		itemName := item.itemName
+		node := g.nodes[itemName]
+		itemType := node.value.Type()
+		external := node.value.External()
+
+		// Explicit item removal.
+		if node.getNewValue() == nil {
+			if !node.created() {
+				// Item is not created, just remove node from the graph.
+				g.removeNode(node)
+				continue
+			}
+			if item.postOrder {
+				// ready for Delete (items depending on this were already traversed)
+				if !external {
+					err = g.getConfigurator(itemType).Delete(ctx, node.value)
+					metrics.deleteCount++
+					if err != nil {
+						node.lastOp = OperationDelete
+						node.lastErr = err
+						node.state = ItemStateFailure
+						node.needSync = false
+						errs = append(errs, err)
+						continue
+					}
+				}
+				g.removeNode(node)
+				continue
+			}
+			// Delete after all items that depends on it are removed first.
+			node.state = ItemStateDeleting
+			stage1Stack.push(stackedItem{itemName: itemName, postOrder: true})
+			g.schedulePreDelOps(node, stage1Stack)
+			continue
+		}
+
+		// Update outgoing edges if needed.
+		if node.needSync && !node.value.Equal(node.newValue) {
+			var deps []Dependency
+			if !external {
+				deps = g.getConfigurator(itemType).DependsOn(node.getNewValue())
+				validateDeps(deps)
+			}
+			g.updateNodeEdges(itemName, deps)
+		}
+
+		// Delete due to unsatisfied dependencies.
+		if !g.hasSatisfiedDeps(node) {
+			if !node.created() {
+				// Cannot create due to a missing dependency.
+				node.state = ItemStatePending
+				if node.needSync {
+					node.value = node.newValue
+					node.needSync = false
+				}
+				continue
+			}
+			if item.postOrder {
+				err = g.getConfigurator(itemType).Delete(ctx, node.value)
+				metrics.deleteCount++
+				node.lastOp = OperationDelete
+				node.lastErr = err
+				if err == nil {
+					node.state = ItemStatePending
+					if node.needSync {
+						node.value = node.newValue
+					}
+				} else {
+					node.state = ItemStateFailure
+					errs = append(errs, err)
+				}
+				node.needSync = false
+				continue
+			}
+			// Delete after all items that depends on it are removed first.
+			node.state = ItemStateDeleting
+			stage1Stack.push(stackedItem{itemName: itemName, postOrder: true})
+			g.schedulePreDelOps(node, stage1Stack)
+			continue
+		}
+
+		// Handle first half of the Recreate
+		if g.needToRecreate(node) {
+			if item.postOrder {
+				err = g.getConfigurator(itemType).Delete(ctx, node.value)
+				metrics.deleteCount++
+				node.lastOp = OperationDelete
+				node.lastErr = err
+				if err == nil {
+					if node.needSync {
+						node.value = node.newValue
+					}
+					// Create is carried out in the next stage.
+					stage2Stack.push(stackedItem{itemName: itemName})
+				} else {
+					node.state = ItemStateFailure
+					errs = append(errs, err)
+				}
+				node.needSync = false
+				continue
+			}
+			// Delete after all items that depends on it are removed first.
+			node.state = ItemStateRecreating
+			stage1Stack.push(stackedItem{itemName: itemName, postOrder: true})
+			g.schedulePreDelOps(node, stage1Stack)
+			continue
+		}
+
+		// Handle item modification.
+		if node.needSync && node.created() {
+			if node.value.Equal(node.newValue) {
+				node.value = node.newValue
+				node.needSync = false
+				continue
+			}
+			if item.postOrder {
+				err = nil
+				if !external {
+					err = g.getConfigurator(itemType).Modify(ctx, node.value, node.newValue)
+					metrics.modifyCount++
+					node.lastOp = OperationModify
+					node.lastErr = err
+				}
+				node.needSync = false
+				if err == nil {
+					node.value = node.newValue
+					// Some pending items might be now ready to be created.
+					// (keep ItemStateModifying)
+					stage2Stack.push(stackedItem{itemName: itemName})
+				} else {
+					node.state = ItemStateFailure
+					errs = append(errs, err)
+				}
+				continue
+			}
+			node.state = ItemStateModifying
+			stage1Stack.push(stackedItem{itemName: itemName, postOrder: true})
+			g.schedulePreModifyOps(node, stage1Stack)
+			continue
+		}
+
+		// Create is processed in the next stage.
+		if !node.created() {
+			stage2Stack.push(stackedItem{itemName: itemName})
+			continue
+		}
+	}
+
+	// Stage 2: Run (Re)Create operations
+	// From every node to be created or that has been modified, run DFS and maybe
+	// create some pending nodes that depend on it in the DFS *pre-order*.
+	// At this stage, a node state may change only in this direction:
+	//  Pending/Recreating/Modifying -> Created/Failure
+	for !stage2Stack.isEmpty() {
+		item, _ := stage2Stack.pop()
+		itemName := item.itemName
+		node := g.nodes[itemName]
+		itemType := node.value.Type()
+		external := node.value.External()
+
+		// Handle (Re)Create.
+		if !node.created() {
+			if !g.hasSatisfiedDeps(node) {
+				continue
+			}
+			err = nil
+			if !external {
+				err = g.getConfigurator(itemType).Create(ctx, node.getNewValue())
+				metrics.createCount++
+				if node.state == ItemStateRecreating {
+					node.lastOp = OperationRecreate
+				} else {
+					node.lastOp = OperationCreate
+				}
+				node.lastErr = err
+			}
+			if node.needSync {
+				node.value = node.newValue
+				node.needSync = false
+			}
+			if err == nil {
+				node.state = ItemStateCreated
+				g.schedulePostPutOps(node, stage2Stack)
+			} else {
+				node.state = ItemStateFailure
+				errs = append(errs, err)
+			}
+			continue
+		}
+
+		// Schedule possible Create operations that follow from a Modify
+		if node.state == ItemStateModifying {
+			g.schedulePostPutOps(node, stage2Stack)
+			node.state = ItemStateCreated
+		}
+
+		if node.needSync {
+			panic(fmt.Sprintf("node %s is unexpectedly not in-sync", node.name))
+		}
+	}
+	return metrics, errs
+}
+
+func (g *depGraph) syncClusterInfo() {
+	for _, cluster := range g.plannedChanges.clusters {
+		info, exists := g.clusters[cluster.path]
+		if exists {
+			info.description = cluster.description
+			continue
+		}
+		info = &clusterInfo{
+			name:        cluster.name,
+			path:        cluster.path,
+			nodeCount:   0,
+			description: cluster.description,
+		}
+		g.clusters[cluster.path] = info
+		// ensure that parent clusters also have an entry
+		for {
+			parentPath := parentClusterPath(info.path)
+			if parentPath == "" {
+				break
+			}
+			info, exists = g.clusters[parentPath]
+			if exists {
+				break
+			}
+			info = &clusterInfo{
+				name: clusterNameFromPath(parentPath),
+				path: parentPath,
+			}
+			g.clusters[parentPath] = info
+		}
+	}
+}
+
+// If changingNode is about to be deleted, iterate over nodes that depend on it
+// and check if they need to be deleted first because their dependencies will no
+// longer be satisfied.
+func (g *depGraph) schedulePreDelOps(changingNode *node, stack *stack) {
+	for _, edge := range g.incomingEdges[changingNode.name] {
+		switch edge.dependency.(type) {
+		case *ItemIsCreated:
+			nodeWithDep := g.nodes[edge.fromNode]
+			if nodeWithDep.created() {
+				// Removal of changingNode breaks dependencies of nodeWithDep.
+				stack.push(stackedItem{itemName: nodeWithDep.name})
+			}
+		default:
+			panic("Unsupported dependency type")
+		}
+	}
+}
+
+// If changingNode is about to be modified, iterate over nodes that depend on it
+// and check if they need to be deleted or recreated.
+func (g *depGraph) schedulePreModifyOps(changingNode *node, stack *stack) {
+	for _, edge := range g.incomingEdges[changingNode.name] {
+		switch dep := edge.dependency.(type) {
+		case *ItemIsCreated:
+			nodeWithDep := g.nodes[edge.fromNode]
+			if nodeWithDep.created() {
+				if dep.MustSatisfy != nil && !dep.MustSatisfy(changingNode.getNewValue()) {
+					// Modification of changingNode breaks dependencies of nodeWithDep.
+					stack.push(stackedItem{itemName: nodeWithDep.name})
+					continue
+				}
+				if dep.RecreateWhenModified {
+					stack.push(stackedItem{itemName: nodeWithDep.name})
+					continue
+				}
+			}
+		default:
+			panic("Unsupported dependency type")
+		}
+	}
+}
+
+// Schedule items to be (re)processed after one of their dependencies was (Re)Created
+// or Modified.
+func (g *depGraph) schedulePostPutOps(node *node, stack *stack) {
+	for _, edge := range g.incomingEdges[node.name] {
+		switch edge.dependency.(type) {
+		case *ItemIsCreated:
+			nodeWithDep := g.nodes[edge.fromNode]
+			if !nodeWithDep.created() && node.state != ItemStateFailure {
+				stack.push(stackedItem{itemName: nodeWithDep.name})
+			}
+		default:
+			panic("Unsupported dependency type")
+		}
+	}
+}
+
+func (g *depGraph) getConfigurator(itemType string) Configurator {
+	configurator := g.configurators[itemType]
+	if configurator == nil {
+		panic(fmt.Sprintf("Missing configurator for item type %s", itemType))
+	}
+	return configurator
+}
+
+// RenderDOT returns DOT description of the graph content. This can be visualized
+// with Graphviz and used for troubleshooting purposes.
+func (g *depGraph) RenderDOT() (dot string, err error) {
+	renderer := &dotRenderer{graph: g}
+	return renderer.render()
+}
+
+func (g *depGraph) clearPlannedChanges() {
+	g.plannedChanges.clusters = make(map[string]clusterInfo)
+	g.plannedChanges.items = make(map[string]itemChange)
+}
+
+// Return index in the array g.sortedNodes at which the given node should be.
+// Note that g.sortedNodes is ordered lexicographically first by node.clusterPath,
+// then node.Name.
+func (g *depGraph) findNodeIndex(nodeName, clusterPath string) (nodeIndex int) {
+	return sort.Search(len(g.sortedNodes), func(i int) bool {
+		node := g.sortedNodes[i]
+		return (node.clusterPath == clusterPath && node.name == nodeName) ||
+			(node.clusterPath == clusterPath && node.name > nodeName) ||
+			node.clusterPath > clusterPath
+	})
+}
+
+// Add new node into the graph together with all outgoing edges representing dependencies.
+// Increases node-counters of all parent clusters.
+// Will panic if the node already exist or if parent clusters do not exist.
+func (g *depGraph) addNewNode(nodeName, clusterPath string, value Item, deps []Dependency) *node {
+	// add to depGraph.nodes
+	if _, exists := g.nodes[nodeName]; exists {
+		panic(fmt.Sprintf("node %s is already present in the graph", nodeName))
+	}
+	node := &node{
+		name:        nodeName,
+		value:       value,
+		clusterPath: clusterPath,
+	}
+	g.nodes[nodeName] = node
+	// add to depGraph.sortedNodes
+	nodeIndex := g.findNodeIndex(nodeName, clusterPath)
+	g.sortedNodes = append(g.sortedNodes, nil)
+	if nodeIndex < len(g.sortedNodes)-1 {
+		copy(g.sortedNodes[nodeIndex+1:], g.sortedNodes[nodeIndex:])
+	}
+	g.sortedNodes[nodeIndex] = node
+	// add edge for every dependency
+	if len(g.outgoingEdges[nodeName]) > 0 {
+		panic(fmt.Sprintf("node %s already has some outgoing edges", nodeName))
+	}
+	for _, itemDep := range deps {
+		g.addNewEdge(nodeName, itemDep)
+	}
+	// increase node-counters of parent clusters
+	parentCluster := clusterPath
+	for parentCluster != "" {
+		g.clusters[parentCluster].nodeCount++
+		parentCluster = parentClusterPath(parentCluster)
+	}
+	return node
+}
+
+// Removes node from the graph, including all incoming and outgoing
+// edges and decreases node-counters of parent clusters.
+func (g *depGraph) removeNode(node *node) {
+	// remove from depGraph.nodes
+	delete(g.nodes, node.name)
+	// remove from depGraph.sortedNodes
+	nodeIndex := g.findNodeIndex(node.name, node.clusterPath)
+	if nodeIndex >= len(g.sortedNodes) || g.sortedNodes[nodeIndex].name != node.name {
+		panic(fmt.Sprintf("node %s is not present in depGraph.sortedNodes",
+			node.name))
+	}
+	if nodeIndex < len(g.sortedNodes)-1 {
+		copy(g.sortedNodes[nodeIndex:], g.sortedNodes[nodeIndex+1:])
+	}
+	g.sortedNodes[len(g.sortedNodes)-1] = nil
+	g.sortedNodes = g.sortedNodes[:len(g.sortedNodes)-1]
+	// decrease node-counters of parent clusters
+	parentCluster := node.clusterPath
+	for parentCluster != "" {
+		g.clusters[parentCluster].nodeCount--
+		parentCluster = parentClusterPath(parentCluster)
+	}
+	// remove all outgoing edges
+	for _, edge := range g.outgoingEdges[node.name] {
+		// remove it from incomingEdges of the opposite node
+		g.removeIncomingEdge(edge)
+	}
+	delete(g.outgoingEdges, node.name)
+}
+
+func (g *depGraph) removeIncomingEdge(edge *edge) {
+	if edge.toNode == "" {
+		// Currently this should not be reachable,
+		// but later we may have edges pointing to something else
+		// than nodes (e.g. clusters), so let's not put panic in here.
+		return
+	}
+	for i, inEdge := range g.incomingEdges[edge.toNode] {
+		// compare pointers
+		if inEdge == edge {
+			g.incomingEdges[edge.toNode] = remove(
+				g.incomingEdges[edge.toNode], i)
+			return
+		}
+	}
+}
+
+func (g *depGraph) addNewEdge(nodeName string, dep Dependency) {
+	switch dep := dep.(type) {
+	case *ItemIsCreated:
+		edge := &edge{
+			fromNode:   nodeName,
+			toNode:     dep.ItemName,
+			dependency: dep,
+		}
+		g.outgoingEdges[nodeName] = append(
+			g.outgoingEdges[nodeName], edge)
+		g.incomingEdges[dep.ItemName] = append(
+			g.incomingEdges[dep.ItemName], edge)
+	default:
+		panic("Unsupported dependency type")
+	}
+}
+
+// Update the node's outgoing edges.
+// Will panic if the node does not exist.
+func (g *depGraph) updateNodeEdges(nodeName string, newDeps []Dependency) {
+	_, exists := g.nodes[nodeName]
+	if !exists {
+		panic(fmt.Sprintf("node %s is not present in the graph", nodeName))
+	}
+	// Remove obsolete edges and update existing ones.
+	edges := g.outgoingEdges[nodeName]
+	for i := 0; i < len(edges); {
+		var found bool
+		edge := edges[i]
+		for _, newDep := range newDeps {
+			if edge.dependency.dependencyKey() == newDep.dependencyKey() {
+				edge.dependency = newDep
+				found = true
+				break
+			}
+		}
+		if !found {
+			edges = remove(edges, i)
+			g.removeIncomingEdge(edge)
+		} else {
+			i++
+		}
+	}
+	g.outgoingEdges[nodeName] = edges
+	// Add new edges.
+	for _, newDep := range newDeps {
+		var found bool
+		for _, edge := range edges {
+			if edge.dependency.dependencyKey() == newDep.dependencyKey() {
+				found = true
+				break
+			}
+		}
+		if !found {
+			g.addNewEdge(nodeName, newDep)
+		}
+	}
+}
+
+// Update the destination cluster of the node.
+// Will panic if the node does not exist.
+func (g *depGraph) updateNodeClusterPath(nodeName, newClusterPath string) {
+	node, exists := g.nodes[nodeName]
+	if !exists {
+		panic(fmt.Sprintf("node %s is not present in the graph", nodeName))
+	}
+	// Decrease node-counters of the previous parent clusters.
+	// Increase node-counters of the new parent clusters.
+	if node.clusterPath != newClusterPath {
+		parentCluster := node.clusterPath
+		for parentCluster != "" {
+			g.clusters[parentCluster].nodeCount--
+			parentCluster = parentClusterPath(parentCluster)
+		}
+		node.clusterPath = newClusterPath
+		parentCluster = node.clusterPath
+		for parentCluster != "" {
+			g.clusters[parentCluster].nodeCount++
+			parentCluster = parentClusterPath(parentCluster)
+		}
+	}
+}
+
+// Check if node has all the dependencies satisfied.
+func (g *depGraph) hasSatisfiedDeps(node *node) bool {
+	if node.value.External() {
+		return true
+	}
+	for _, edge := range g.outgoingEdges[node.name] {
+		if !g.isSatisfiedDep(edge) {
+			return false
+		}
+	}
+	return true
+}
+
+// Check if the dependency represented by the edge is satisfied.
+func (g *depGraph) isSatisfiedDep(edge *edge) bool {
+	switch dep := edge.dependency.(type) {
+	case *ItemIsCreated:
+		depNode, exists := g.nodes[edge.toNode]
+		if !exists {
+			return false
+		}
+		if !depNode.created() {
+			return false
+		}
+		if depNode.state == ItemStateRecreating ||
+			depNode.state == ItemStateDeleting {
+			return false
+		}
+		if depNode.getNewValue() == nil {
+			return false
+		}
+		if dep.MustSatisfy != nil {
+			if !dep.MustSatisfy(depNode.value) {
+				return false
+			}
+			if depNode.needSync && !dep.MustSatisfy(depNode.getNewValue()) {
+				return false
+			}
+		}
+	default:
+		panic("Unsupported dependency type")
+	}
+	return true
+}
+
+// Returns true if this node needs to be Re-created.
+func (g *depGraph) needToRecreate(node *node) bool {
+	if node.state == ItemStateRecreating {
+		return true
+	}
+	if node.value.External() || !node.created() {
+		return false
+	}
+	for _, edge := range g.outgoingEdges[node.name] {
+		switch dep := edge.dependency.(type) {
+		case *ItemIsCreated:
+			depNode, exists := g.nodes[edge.toNode]
+			if exists && depNode.state == ItemStateModifying {
+				if dep.RecreateWhenModified {
+					return true
+				}
+			}
+		default:
+			panic("Unsupported dependency type")
+		}
+	}
+	modify := node.needSync && node.created() && !node.value.Equal(node.newValue)
+	if modify {
+		itemType := node.value.Type()
+		return g.getConfigurator(itemType).NeedsRecreate(node.value, node.newValue)
+	}
+	return false
+}
+
+func validateDeps(deps []Dependency) {
+	// Check if dependency is supported.
+	for _, dep := range deps {
+		switch dep.(type) {
+		case *ItemIsCreated:
+			// OK
+		default:
+			panic("Unsupported dependency type")
+		}
+	}
+	// Multiple ItemIsCreated pointing to the same item are not allowed.
+	for i := 0; i < len(deps); i++ {
+		for j := i + 1; j < len(deps); j++ {
+			if deps[i].dependencyKey() == deps[j].dependencyKey() {
+				// Strictly speaking this is a programming error,
+				// so let's just lazily put panic in here.
+				panic(fmt.Sprintf("Duplicate dependencies (%s)",
+					deps[i].dependencyKey()))
+			}
+		}
+	}
+}

--- a/pkg/pillar/depgraph/depgraph_api.go
+++ b/pkg/pillar/depgraph/depgraph_api.go
@@ -1,0 +1,368 @@
+// Copyright (c) 2021 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package depgraph
+
+import "context"
+
+// DepGraph is a dependency graph [1].
+// In EVE, the main use-case is to represent configuration items (interfaces, bridges,
+// domains, etc.) as graph nodes and their dependencies as directed graph edges.
+// For example, if there are nodes A and B with edge A->B, and the dependency is of type
+// ItemIsCreated, then B should be created before A. Conversely, the removal of these
+// two items should proceed in the opposite order, i.e. A should be removed first
+// (think of it as "A cannot exist without B").
+//
+// The graph as a whole is used to represent the intended state of configuration items.
+// However, the graph not only allows to store the configuration, but also to execute
+// synchronization procedure (Sync() method), which performs all configuration changes,
+// in an order that respects dependencies, to get from the current state to a new
+// intended state. The actual configuration changes are delegated to Configurators,
+// each registered with a specific type of configuration items (returned by Item.Type();
+// type can be for example "Linux bridge").
+// Configurator implements Create, Modify and Delete operations and also describes
+// dependencies for a configuration item, which DepGraph uses to build graph edges.
+// Apart from state synchronization, operation ordering and execution, the graph also
+// keeps some state information for every item, for example the last error value.
+//
+// In order to make changes to the graph content (the intended state), first select
+// a single item or a subset of the graph using Selector and call Put/Del methods
+// as defined by ItemOps and ClusterOps. Once the new intended state is constructed,
+// run Sync() to apply the changes down to the current system state through Configurators.
+// The graph is NOT thread-safe. It is supposed to be used exclusively from within
+// the main loop of a microservice.
+//
+// The concept of item clustering is borrowed from Graphviz [2]. Here the clusters are
+// used to group related items and allow to select and edit them together.
+// For example, all components of a network instance (bridge, routes, dnsmasq, etc.)
+// can be grouped into one cluster with the name of the network instance. Then,
+// if the network instance is removed, the intended state can be updated as easily as:
+//     graph.Cluster(<NI-name>).Del()
+// Also, the entire content of a cluster can be replaced with:
+//     graph.Cluster(<name>).Put(<new-content>)
+// DepGraph will run a "diff" algorithm to automatically determine which items should
+// be created/modified/deleted.
+// Clusters can be also nested and thus compose a hierarchical tree structure.
+// This is very similar to directory structure of a filesystem if you think of clusters
+// as directories and items as files.
+// Top-level cluster has empty name and represents the graph as a whole.
+// Currently, clustering is not related to and does not affect dependencies.
+//
+// The graph content can be exported into DOT [3] and then visualized for example
+// using Graphviz [4]. Item clustering also helps here because related items are drawn
+// together and contained within a rectangle.
+//
+// DepGraph is a generic solution for a common problem. The current implementation
+// is very simple with a plenty of room for optimizations and improvements. For example,
+// Configurators could be extended with Read operations (i.e. provide complete CRUD),
+// and DepGraph could implement a full reconciliation between the actual and the intended
+// state (similar to what Controllers in Kubernetes do). Currently, DepGraph assumes that
+// the actual state is the same as the intended state of the last Sync() - but this could
+// be wrong assumption if some operations failed or if the state changed somehow due to external
+// factors. Additionally, DepGraph could automatically retry or revert failed operations.
+// Also, since Dependency is just an interface, new kinds of dependencies with different semantic
+// could be added as needed. But the main point is that all this functionality only needs
+// to be implemented and maintained in one place.
+//
+// [1]: https://en.wikipedia.org/wiki/Dependency_graph
+// [2]: https://graphviz.org/Gallery/directed/cluster.html
+// [3]: https://en.wikipedia.org/wiki/DOT_(graph_description_language)
+// [4]: https://graphviz.org/
+type DepGraph interface {
+	// Methods to select a single item or a subset of the graph and make changes to it.
+	Selector
+
+	// RegisterConfigurator makes association between a Configurator and items
+	// of the given type. When changes are made to the intended configuration for
+	// these items, DepGraph will know where to look for the implementation
+	// of the Create, Modify and Delete operations and will call them from Sync().
+	// Additionally, Configurator is used by DepGraph to learn the dependencies of an item.
+	RegisterConfigurator(configurator Configurator, itemType string) error
+
+	// Sync performs all Create/Modify/Delete operations (provided by Configurators)
+	// to get the (new) intended and the actual (previous intended) state in-sync.
+	// Currently, it is assumed that the actual state is the same as the intended state
+	// of the last Sync() and the new intended state additionally contains all the changes
+	// that were made to the graph since.
+	// Operations are performed in the topological order with respect to the dependencies.
+	// It is recommended to call this at the end of a microservice main loop, i.e.:
+	//
+	// graph := NewDepGraph()
+	// graph.RegisterConfigurator(configurator, itemType)
+	// ...
+	// for {
+	//     select {
+	//         case <-sub1:
+	//             ... // potentially make changes to the intended state
+	//         case <-sub2:
+	//             ...
+	//     }
+	//     graph.Sync()
+	// }
+	Sync(ctx context.Context) error
+
+	// RenderDOT returns DOT description of the graph content. This can be visualized
+	// with Graphviz and used for troubleshooting purposes.
+	RenderDOT() (dot string, err error)
+}
+
+// Selector allows to select a single item or a subset of the graph and make changes to it.
+// Note that changes do not take effect until DepGraph.Sync() is called.
+type Selector interface {
+	// Note: Top-level cluster has empty name and covers the entire graph.
+	ClusterOps
+	// Item : Select item with the specified name.
+	Item(name string) ItemOps
+	// Cluster : Select (sub-)cluster with the specified name.
+	Cluster(name string) Selector
+}
+
+// ItemOps : operations to change/get the intended state of a single item.
+// Note that changes do not take effect until DepGraph.Sync() is called.
+type ItemOps interface {
+	// Put : Create/Modify item.
+	Put(item Item)
+	// Del : Delete item.
+	Del()
+	// Get : Get summary info for the item from DepGraph.
+	// This summary corresponds to the item state after the last Sync().
+	Get() (itemSummary ItemSummary, exists bool)
+}
+
+// ClusterOps : operations to change/get the intended state of all items inside
+// a particular cluster.
+// Note that changes do not take effect until DepGraph.Sync() is called.
+type ClusterOps interface {
+	// Put : Replace all items and sub-clusters inside this cluster.
+	Put(cluster Cluster)
+	// Del : Delete entire cluster with all items and sub-clusters it contains.
+	Del()
+	// Get : Get summary info for all items in the cluster from DepGraph.
+	// This summary corresponds to the state after the last Sync().
+	Get() (clusterSummary ClusterSummary, exists bool)
+}
+
+// Item is something that can be created, modified and deleted.
+// This could be for example a network interface, volume instance, configuration file, etc.
+// In DepGraph, each item is represented as a single graph node.
+// Note that the term "node" is already overused in EVE and intentionally not used here.
+// Beware that items are stored inside the graph and their content should not change
+// in any other way than through the DepGraph APIs. It is recommended to implement the Item
+// interface with *value* receivers (or alternatively pass *copied* item values to the graph).
+type Item interface {
+	// Name should return a unique string identifier for the item instance.
+	// The name should be unique across *all* items (of all item types and in all clusters).
+	Name() string
+	// Type groups item instances handled by the same Configurator.
+	// For example, type could be "Linux bridge".
+	Type() string
+	// Equal compares this and the other item instance (of the same name)
+	// for equivalency.
+	// If the current and the new intended state of an item is equal, then DepGraph
+	// will not call Modify.
+	Equal(Item) bool
+	// External should return true for items which are not created/modified/deleted
+	// by this instance of DepGraph using a Configurator (i.e. do not register
+	// Configurator with external items).
+	// This could be used for items created by other microservices.
+	// Presence of external items in the graph is used only for dependency purposes.
+	// (e.g. create A only after another microservice created B).
+	External() bool
+	// String should return a human-readable description of the item instance.
+	// (e.g. a network interface configuration)
+	String() string
+}
+
+// Dependency of an item.
+// The interface methods are intentionally lower-case because Dependency implementation
+// can only come from the DepGraph package itself.
+type Dependency interface {
+	// Dependencies of a given item should each have a unique key, otherwise they are
+	// treated as duplicates.
+	// In other words, Configurator.DependsOn() should not return multiple dependencies
+	// with the same key.
+	dependencyKey() string
+	//  String should return a human-readable description of the dependency.
+	String() string
+}
+
+// ItemIsCreated is a dependency which is satisfied if Item with the name ItemName
+// is already created and MustSatisfy returns true for that item or is nil.
+type ItemIsCreated struct {
+	// ItemName : name of an item which must be already created.
+	ItemName string
+	// MustSatisfy : used if the referenced item must not only exist but also satisfy
+	// a certain condition. For example, a network route may depend on a specific network
+	// interface to exist and also to have a specific IP address assigned. MustSatisfy can
+	// check for the presence of the IP address.
+	// This function may get called quite often so keep it lightweight.
+	MustSatisfy func(Item) bool
+	// RecreateWhenModified : Whenever the referenced item changes (through Modify), recreate
+	// the items that depend on it.
+	RecreateWhenModified bool
+	// Description : optional description of the dependency.
+	Description string
+}
+
+func (dep ItemIsCreated) dependencyKey() string {
+	return dep.ItemName
+}
+
+// String returns dependency description.
+func (dep ItemIsCreated) String() string {
+	return dep.Description
+}
+
+// Cluster allows to group items which are in some way related to each other.
+// For example, all components of the same application (domain, volumes, VIFs),
+// could be grouped under one cluster.
+// This is mostly used to simplify graph modifications. For example, cluster
+// as whole, with all the items it contains, can be removed with one call
+// (to ClusterOps.Del()) or the content can be replaced with a new set of items
+// (using ClusterOps.Put()). When the content is replaced, DepGraph will run a "diff"
+// algorithm to automatically determine which items should be created/modified/deleted
+// (i.e. you do not have to implement "diff" yourself).
+// Clusters can be also nested and thus compose a hierarchical tree structure.
+// This is very similar to directory structure of a filesystem if you think of clusters
+// as directories and items as files.
+// Top-level cluster has empty name and represents the graph as a whole.
+// Currently, clustering is not related to and does not affect dependencies.
+type Cluster struct {
+	// Name of the cluster.
+	// Should be unique at least within the parent cluster.
+	// Name is not allowed to contain the forward slash character ("/").
+	Name string
+	// Some human-readable explanation of the cluster's purpose.
+	Description string
+	Items       []Item
+	SubClusters []Cluster
+}
+
+// ItemState : state of an item inside the dependency graph.
+type ItemState int
+
+const (
+	// ItemStateUnknown : item state is not known.
+	ItemStateUnknown ItemState = iota
+	// ItemStateCreated : item is successfully created.
+	ItemStateCreated
+	// ItemStatePending : item cannot be yet created because one or more
+	// dependencies are not satisfied.
+	ItemStatePending
+	// ItemStateFailure : last Create/Modify/Delete operation failed.
+	// Expect to find non-nil LastError inside ItemSummary.
+	ItemStateFailure
+	// ItemStateDeleting : item is being removed. This is only an intermittent
+	// item state used during the DepGraph.Sync() procedure. It is never
+	// returned by ItemOps.Get() or ClusterOps.Get().
+	ItemStateDeleting
+	// ItemStateModifying : item is being modified. This is only an intermittent
+	// item state used during the DepGraph.Sync() procedure. It is never
+	// returned by ItemOps.Get() or ClusterOps.Get().
+	ItemStateModifying
+	// ItemStateRecreating : item is being re-created. This is only an intermittent
+	// item state used during the DepGraph.Sync() procedure. It is never
+	// returned by ItemOps.Get() or ClusterOps.Get().
+	ItemStateRecreating
+)
+
+// String returns string representation of the item state.
+func (s ItemState) String() string {
+	switch s {
+	case ItemStateUnknown:
+		return "unknown"
+	case ItemStateCreated:
+		return "created"
+	case ItemStatePending:
+		return "pending"
+	case ItemStateFailure:
+		return "failure"
+	case ItemStateDeleting:
+		return "deleting"
+	case ItemStateModifying:
+		return "modifying"
+	case ItemStateRecreating:
+		return "recreating"
+	}
+	return ""
+}
+
+// Operation : operation done over an item through a Configurator.
+type Operation int
+
+const (
+	// OperationUnknown : unknown operation
+	OperationUnknown Operation = iota
+	// OperationCreate : Configurator.Create() was called
+	OperationCreate
+	// OperationDelete : Configurator.Delete() was called
+	OperationDelete
+	// OperationModify : Configurator.Modify() was called
+	OperationModify
+	// OperationRecreate : Configurator.Delete() followed by Configurator.Create() was called
+	OperationRecreate
+)
+
+// String returns string representation of the operation.
+func (o Operation) String() string {
+	switch o {
+	case OperationUnknown:
+		return "unknown"
+	case OperationCreate:
+		return "create"
+	case OperationDelete:
+		return "delete"
+	case OperationModify:
+		return "modify"
+	case OperationRecreate:
+		return "recreate"
+	}
+	return ""
+}
+
+// ItemSummary encapsulates summary information for a single item.
+type ItemSummary struct {
+	Item        Item
+	State       ItemState
+	LastOp      Operation
+	LastError   error
+	ClusterPath string // Path to the item's parent cluster
+}
+
+// ClusterSummary encapsulates summary information for all items and sub-clusters
+// contained by a cluster.
+type ClusterSummary struct {
+	Name        string
+	Description string
+	// ClusterPath is the path to this cluster from the top of the graph.
+	// Forward-slash is used to separate names of the clusters that the path
+	// consists of.
+	// (just like absolute path to a directory in the Unix-like systems).
+	ClusterPath string
+	// Items are sorted by their names.
+	Items []ItemSummary
+	// Nested clusters are sorted by their names.
+	SubClusters []ClusterSummary
+}
+
+// Configurator implements Create, Modify and Delete operations for items of the same type.
+// For DepGraph it is a "backend" which the graph calls as needed to sync the actual and
+// the intended state.
+// Additionally, Configurator is used by DepGraph to learn the dependencies of an item.
+type Configurator interface {
+	// Create should create the item (e.g. create a Linux bridge with the given parameters).
+	Create(ctx context.Context, item Item) error
+	// Modify should change the item to the new desired state (e.g. change interface IP address).
+	Modify(ctx context.Context, oldItem, newItem Item) (err error)
+	// Delete should remove the item (e.g. stop application domain).
+	Delete(ctx context.Context, item Item) error
+	// NeedsRecreate should return true if changing the item to the new desired state
+	// requires the item to be completely re-created. DepGraph will then perform the change
+	// as Delete(oldItem) followed by Create(newItem) instead of calling Modify.
+	NeedsRecreate(oldItem, newItem Item) (recreate bool)
+	// DependsOn returns a list of all dependencies that have to be satisfied before
+	// the item can be created (i.e. dependencies in the returned list are AND-ed).
+	// Item which cannot be created due to unsatisfied dependencies will be internally marked
+	// as pending with ItemStatePending (DepGraph allows to obtain the current state of items).
+	DependsOn(item Item) []Dependency
+}

--- a/pkg/pillar/depgraph/depgraph_dot.go
+++ b/pkg/pillar/depgraph/depgraph_dot.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2021 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package depgraph
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+type dotRenderer struct {
+	graph *depGraph
+}
+
+const (
+	indentChar = "\t"
+)
+
+// Return DOT description of the graph content. This can be visualized
+// with Graphviz and used for troubleshooting purposes.
+func (r *dotRenderer) render() (dot string, err error) {
+	sb := strings.Builder{}
+	sb.WriteString("digraph G {\n")
+	// Render clusters starting with the implicit top-level one.
+	_, err = r.renderCluster(&sb, clusterPathSep, 0, indentChar)
+	if err != nil {
+		return "", err
+	}
+	// Output all edges.
+	missingNodes := make(map[string]struct{}) // not in the graph but with edges pointing to them
+	for _, edges := range r.graph.outgoingEdges {
+		for _, edge := range edges {
+			if edge.toNode == "" {
+				continue
+			}
+			if _, exists := r.graph.nodes[edge.toNode]; !exists {
+				missingNodes[edge.toNode] = struct{}{}
+			}
+			var color string
+			if r.graph.isSatisfiedDep(edge) {
+				color = "black"
+			} else {
+				color = "red"
+			}
+			sb.WriteString(fmt.Sprintf("%s%s -> %s [color = %s, tooltip = \"%s\"];\n",
+				indentChar, escapeName(edge.fromNode), escapeName(edge.toNode), color,
+				escapeTooltip(edge.dependency.String())))
+		}
+	}
+	for node := range missingNodes {
+		sb.WriteString(fmt.Sprintf("%s%s [color = grey, style = dashed, "+
+			"tooltip = \"<missing>\"];\n", indentChar, escapeName(node)))
+	}
+	sb.WriteString("}\n")
+	return sb.String(), nil
+}
+
+func (r *dotRenderer) renderCluster(w io.StringWriter, clusterPath string,
+	firstNode int, indent string) (nodeAfter int, err error) {
+	nestedIndent := indent
+
+	// output cluster header
+	clusterName := clusterNameFromPath(clusterPath)
+	if clusterName != "" {
+		nestedIndent += indentChar
+		cluster, ok := r.graph.clusters[clusterPath]
+		if !ok {
+			return 0, fmt.Errorf("failed to get info for cluster %s",
+				clusterPath)
+		}
+		w.WriteString(fmt.Sprintf("%ssubgraph cluster_%s {\n",
+			indent, escapeName(clusterName)))
+		w.WriteString(fmt.Sprintf("%scolor = blue;\n", nestedIndent))
+		w.WriteString(fmt.Sprintf("%slabel = %s;\n",
+			nestedIndent, escapeName(cluster.name)))
+		w.WriteString(fmt.Sprintf("%stooltip = \"%s\";\n",
+			nestedIndent, escapeTooltip(cluster.description)))
+	}
+
+	// output nodes and sub-clusters
+	i := firstNode
+	for i < len(r.graph.nodes) {
+		node := r.graph.sortedNodes[i]
+		if !strings.HasPrefix(node.clusterPath, clusterPath) {
+			break
+		}
+		if node.clusterPath == clusterPath {
+			var color string
+			switch node.state {
+			case ItemStatePending:
+				color = "grey"
+			case ItemStateFailure:
+				color = "red"
+			default:
+				color = "black"
+			}
+			w.WriteString(fmt.Sprintf("%s%s [color = %s, tooltip = \"%s\"];\n",
+				nestedIndent, escapeName(node.name), color,
+				escapeTooltip(node.value.String())))
+			i++
+			continue
+		}
+
+		// node is from a sub-cluster
+		suffix := node.clusterPath[len(clusterPath):]
+		nextSep := strings.Index(suffix, clusterPathSep)
+		if nextSep == -1 {
+			panic(fmt.Sprintf("invalid cluster path: %s", node.clusterPath))
+		}
+		subClusterPath := node.clusterPath[:len(clusterPath)+nextSep+len(clusterPathSep)]
+		i, err = r.renderCluster(w, subClusterPath, i, nestedIndent)
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	// closing cluster bracket
+	if clusterName != "" {
+		w.WriteString(indent + "}\n")
+	}
+	return i, err
+}
+
+func escapeName(name string) string {
+	return strings.Replace(name, "-", "_", -1)
+}
+
+func escapeTooltip(tooltip string) string {
+	return strings.Replace(tooltip, "\n", "\\n", -1)
+}

--- a/pkg/pillar/depgraph/depgraph_matchers_test.go
+++ b/pkg/pillar/depgraph/depgraph_matchers_test.go
@@ -1,0 +1,219 @@
+// Copyright (c) 2021 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package depgraph_test
+
+import (
+	"fmt"
+
+	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/types"
+
+	"github.com/lf-edge/eve/pkg/pillar/depgraph"
+)
+
+// OperationMatcher : match operation inside operationsLog.
+type OperationMatcher interface {
+	types.GomegaMatcher
+	WithError(errMsg string) types.GomegaMatcher
+	Before(item mockItem) RefOperationMatcher
+	After(item mockItem) RefOperationMatcher
+}
+
+// RefOperationMatcher : reference another operation and check the relative ordering.
+type RefOperationMatcher interface {
+	types.GomegaMatcher
+	IsCreated() types.GomegaMatcher
+	IsDeleted() types.GomegaMatcher
+	IsModified() types.GomegaMatcher
+	IsRecreated() types.GomegaMatcher
+}
+
+type expectedOp struct {
+	item mockItem
+	op   depgraph.Operation
+}
+
+// BeCreated : Expect item to be created inside DepGraph.Sync().
+func BeCreated() OperationMatcher {
+	return &opMatcher{
+		expOp: depgraph.OperationCreate,
+	}
+}
+
+// BeDeleted : Expect item to be deleted inside DepGraph.Sync().
+func BeDeleted() OperationMatcher {
+	return &opMatcher{
+		expOp: depgraph.OperationDelete,
+	}
+}
+
+// BeModified : Expect item to be modified inside DepGraph.Sync().
+func BeModified() OperationMatcher {
+	return &opMatcher{
+		expOp: depgraph.OperationModify,
+	}
+}
+
+// BeRecreated : Expect item to be re-created inside DepGraph.Sync().
+func BeRecreated() OperationMatcher {
+	return &opMatcher{
+		expOp: depgraph.OperationRecreate,
+	}
+}
+
+// opMatcher implements OperationMatcher
+type opMatcher struct {
+	expOp     depgraph.Operation
+	expBefore *expectedOp
+	expAfter  *expectedOp
+	expError  string
+}
+
+func (m *opMatcher) Match(actual interface{}) (success bool, err error) {
+	item, ok := actual.(mockItem)
+	if !ok {
+		return false, fmt.Errorf("OperationMatcher expects a mock Item")
+	}
+	opLog := ctx.opsLog.find(item, m.expOp)
+	if opLog == nil {
+		return false, nil
+	}
+	var opErr string
+	if opLog.err != nil {
+		opErr = opLog.err.Error()
+	}
+	if m.expError != opErr {
+		return false, nil
+	}
+	if m.expBefore != nil {
+		opLog2 := ctx.opsLog.find(m.expBefore.item, m.expBefore.op)
+		if opLog2 == nil {
+			return false, nil
+		}
+		if opLog.index > opLog2.index {
+			return false, nil
+		}
+	}
+	if m.expAfter != nil {
+		opLog2 := ctx.opsLog.find(m.expAfter.item, m.expAfter.op)
+		if opLog2 == nil {
+			return false, nil
+		}
+		if opLog.index < opLog2.index {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func expOpToString(expOp depgraph.Operation) string {
+	switch expOp {
+	case depgraph.OperationCreate:
+		return "created"
+	case depgraph.OperationDelete:
+		return "deleted"
+	case depgraph.OperationModify:
+		return "modified"
+	case depgraph.OperationRecreate:
+		return "recreated"
+	}
+	return "<unknown>"
+}
+
+func (m *opMatcher) failureMessage(actual interface{}, negated bool) (message string) {
+	var expVerb, expOp, expErr, expOrder string
+	expVerb = "be"
+	if negated {
+		expVerb = "NOT " + expVerb
+	}
+	expOp = expOpToString(m.expOp)
+	expErr = "successfully"
+	if m.expError != "" {
+		expErr = fmt.Sprintf("with error %s", m.expError)
+	}
+	if m.expBefore != nil {
+		expOrder = fmt.Sprintf("before item\n%s is %s",
+			format.Object(m.expBefore.item, 1),
+			expOpToString(m.expBefore.op))
+	}
+	if m.expAfter != nil {
+		expOrder = fmt.Sprintf("after item\n%s is %s",
+			format.Object(m.expAfter.item, 1),
+			expOpToString(m.expAfter.op))
+	}
+	actualOps := fmt.Sprintf("Actual Sync operations:\n%v", ctx.opsLog)
+	return fmt.Sprintf("Expected\n%s\nto %s %s %s %s\n%s",
+		format.Object(actual, 1), expVerb, expOp, expErr, expOrder,
+		actualOps)
+
+}
+
+func (m *opMatcher) FailureMessage(actual interface{}) (message string) {
+	return m.failureMessage(actual, false)
+}
+
+func (m *opMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return m.failureMessage(actual, true)
+}
+
+func (m *opMatcher) WithError(errMsg string) types.GomegaMatcher {
+	m.expError = errMsg
+	return m
+}
+
+func (m *opMatcher) Before(item mockItem) RefOperationMatcher {
+	m.expBefore = &expectedOp{
+		item: item,
+		op:   m.expOp,
+	}
+	return m
+}
+
+func (m *opMatcher) After(item mockItem) RefOperationMatcher {
+	m.expAfter = &expectedOp{
+		item: item,
+		op:   m.expOp,
+	}
+	return m
+}
+
+func (m *opMatcher) IsCreated() types.GomegaMatcher {
+	if m.expBefore != nil {
+		m.expBefore.op = depgraph.OperationCreate
+	}
+	if m.expAfter != nil {
+		m.expAfter.op = depgraph.OperationCreate
+	}
+	return m
+}
+
+func (m *opMatcher) IsModified() types.GomegaMatcher {
+	if m.expBefore != nil {
+		m.expBefore.op = depgraph.OperationModify
+	}
+	if m.expAfter != nil {
+		m.expAfter.op = depgraph.OperationModify
+	}
+	return m
+}
+
+func (m *opMatcher) IsDeleted() types.GomegaMatcher {
+	if m.expBefore != nil {
+		m.expBefore.op = depgraph.OperationDelete
+	}
+	if m.expAfter != nil {
+		m.expAfter.op = depgraph.OperationDelete
+	}
+	return m
+}
+
+func (m *opMatcher) IsRecreated() types.GomegaMatcher {
+	if m.expBefore != nil {
+		m.expBefore.op = depgraph.OperationRecreate
+	}
+	if m.expAfter != nil {
+		m.expAfter.op = depgraph.OperationRecreate
+	}
+	return m
+}

--- a/pkg/pillar/depgraph/depgraph_mock_test.go
+++ b/pkg/pillar/depgraph/depgraph_mock_test.go
@@ -1,0 +1,212 @@
+// Copyright (c) 2021 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package depgraph_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/lf-edge/eve/pkg/pillar/depgraph"
+)
+
+// log entry for a single (mock) operation
+type opLog struct {
+	item  mockItem
+	op    depgraph.Operation
+	err   error
+	index int
+}
+
+// log of operations for a single DepGraph.Sync() call
+type operationsLog struct {
+	log []opLog
+}
+
+func (l *operationsLog) recordOp(item mockItem, op depgraph.Operation, err error) {
+	l.log = append(l.log, opLog{
+		item:  item,
+		op:    op,
+		err:   err,
+		index: len(l.log),
+	})
+}
+
+func (l *operationsLog) clear() {
+	l.log = []opLog{}
+}
+
+func (l *operationsLog) find(item mockItem, op depgraph.Operation) *opLog {
+	var deleted bool
+	for _, logEntry := range l.log {
+		if logEntry.item.Name() != item.Name() {
+			continue
+		}
+		if op == logEntry.op ||
+			(op == depgraph.OperationRecreate &&
+				deleted && logEntry.op == depgraph.OperationCreate) {
+			return &logEntry
+		}
+		deleted = logEntry.op == depgraph.OperationDelete
+	}
+	return nil
+}
+
+func (l *operationsLog) String() string {
+	var ops []string
+	for _, op := range l.log {
+		var withError string
+		if op.err != nil {
+			withError = " with error " + op.err.Error()
+		}
+		ops = append(ops, fmt.Sprintf("%s item %s%s",
+			strings.Title(op.op.String()), op.item.name, withError))
+	}
+	return strings.Join(ops, "\n")
+}
+
+type mockItemDepsClb func(staticAttrs, modifiableAttrs mockItemAttrs) []depgraph.Dependency
+
+type mockConfigurator struct {
+	itemType    string
+	opsLog      *operationsLog
+	itemDepsClb mockItemDepsClb
+}
+
+func (m *mockConfigurator) Create(ctx context.Context, item depgraph.Item) (err error) {
+	mItem, ok := item.(mockItem)
+	if !ok {
+		panic("mockConfigurator only works with mockItem")
+	}
+	if item.Type() != m.itemType {
+		panic("DepGraph called wrong Configurator")
+	}
+	if item.External() {
+		panic("external item should not have configurator associated")
+	}
+	if mItem.failToCreate {
+		err = errors.New("failed to create")
+	}
+	if m.opsLog != nil {
+		m.opsLog.recordOp(mItem, depgraph.OperationCreate, err)
+	}
+	return err
+}
+
+func (m *mockConfigurator) Modify(ctx context.Context, oldItem, newItem depgraph.Item) (err error) {
+	if oldItem.Name() != newItem.Name() {
+		panic("Modify called between different items")
+	}
+	if newItem.Type() != m.itemType {
+		panic("DepGraph called wrong Configurator")
+	}
+	_, ok := oldItem.(mockItem)
+	if !ok {
+		panic("mockConfigurator only works with mockItem")
+	}
+	mNewItem, ok := newItem.(mockItem)
+	if !ok {
+		panic("mockConfigurator only works with mockItem")
+	}
+	if oldItem.Equal(newItem) {
+		panic("Modify called for item which has not changed")
+	}
+	if newItem.External() {
+		panic("external item should not have configurator associated")
+	}
+	if mNewItem.failToCreate {
+		err = errors.New("failed to modify")
+	}
+	if m.opsLog != nil {
+		m.opsLog.recordOp(mNewItem, depgraph.OperationModify, err)
+	}
+	return err
+}
+
+func (m *mockConfigurator) Delete(ctx context.Context, item depgraph.Item) (err error) {
+	mItem, ok := item.(mockItem)
+	if !ok {
+		panic("mockConfigurator only works with mockItem")
+	}
+	if item.Type() != m.itemType {
+		panic("DepGraph called wrong Configurator")
+	}
+	if item.External() {
+		panic("external item should not have configurator associated")
+	}
+	if mItem.failToDelete {
+		err = errors.New("failed to delete")
+	}
+	if m.opsLog != nil {
+		m.opsLog.recordOp(mItem, depgraph.OperationDelete, err)
+	}
+	return err
+}
+
+func (m *mockConfigurator) NeedsRecreate(oldItem, newItem depgraph.Item) (recreate bool) {
+	if newItem.Type() != m.itemType {
+		panic("DepGraph called wrong Configurator")
+	}
+	mOldItem, ok := oldItem.(mockItem)
+	if !ok {
+		panic("mockConfigurator only works with mockItem")
+	}
+	mNewItem, ok := newItem.(mockItem)
+	if !ok {
+		panic("mockConfigurator only works with mockItem")
+	}
+	return !reflect.DeepEqual(mOldItem.staticAttrs, mNewItem.staticAttrs)
+}
+
+func (m *mockConfigurator) DependsOn(item depgraph.Item) []depgraph.Dependency {
+	mItem, ok := item.(mockItem)
+	if !ok {
+		panic("mockConfigurator only works with mockItem")
+	}
+	if m.itemDepsClb != nil {
+		return m.itemDepsClb(mItem.staticAttrs, mItem.modifiableAttrs)
+	}
+	return []depgraph.Dependency{}
+}
+
+type mockItemAttrs struct {
+	intAttr   int
+	strAttr   string
+	boolAttr  bool
+	sliceAttr []string
+}
+
+type mockItem struct {
+	name            string
+	itemType        string
+	isExternal      bool
+	staticAttrs     mockItemAttrs // change of these requires purge
+	modifiableAttrs mockItemAttrs // can be changed by Modify
+	failToCreate    bool          // enable to simulate failed Create/Modify
+	failToDelete    bool          // enable to simulate failed Delete
+}
+
+func (m mockItem) Name() string {
+	return m.name
+}
+
+func (m mockItem) Type() string {
+	return m.itemType
+}
+
+func (m mockItem) Equal(m2 depgraph.Item) bool {
+	return reflect.DeepEqual(m.modifiableAttrs, m2.(mockItem).modifiableAttrs) &&
+		reflect.DeepEqual(m.staticAttrs, m2.(mockItem).staticAttrs)
+}
+
+func (m mockItem) External() bool {
+	return m.isExternal
+}
+
+func (m mockItem) String() string {
+	return fmt.Sprintf("item %s with attrs: %v; %v",
+		m.name, m.modifiableAttrs, m.staticAttrs)
+}

--- a/pkg/pillar/depgraph/depgraph_selectors.go
+++ b/pkg/pillar/depgraph/depgraph_selectors.go
@@ -1,0 +1,187 @@
+// Copyright (c) 2021 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package depgraph
+
+import (
+	"fmt"
+	"strings"
+)
+
+// clusterSelector implements Selector interface.
+type clusterSelector struct {
+	graph       *depGraph
+	clusterPath string
+}
+
+// itemSelector implements ItemOps interface.
+type itemSelector struct {
+	graph       *depGraph
+	itemName    string
+	clusterPath string
+}
+
+// Item : Select item with the specified name.
+func (s *clusterSelector) Item(name string) ItemOps {
+	return &itemSelector{
+		graph:       s.graph,
+		itemName:    name,
+		clusterPath: s.clusterPath,
+	}
+}
+
+// Cluster : Select (sub-)cluster with the specified name.
+func (s *clusterSelector) Cluster(name string) Selector {
+	return &clusterSelector{
+		graph:       s.graph,
+		clusterPath: s.clusterPath + name + clusterPathSep,
+	}
+}
+
+// Put : Replace all items and sub-clusters inside this cluster.
+func (s *clusterSelector) Put(cluster Cluster) {
+	if clusterNameFromPath(s.clusterPath) != cluster.Name {
+		panic("cluster name mismatch")
+	}
+	// Clear (set for Delete) all current items in this cluster.
+	// For some, the nil value will be replaced with a new (or the same as before)
+	// value in s.putCluster() below.
+	_, alreadyChanged := s.graph.plannedChanges.clusters[s.clusterPath]
+	if alreadyChanged {
+		for itemName, item := range s.graph.plannedChanges.items {
+			if strings.HasPrefix(item.clusterPath, s.clusterPath) {
+				item.newValue = nil
+				s.graph.plannedChanges.items[itemName] = item
+			}
+		}
+	} else {
+		s.Del()
+	}
+	s.putCluster(cluster, s.clusterPath)
+}
+
+func (s *clusterSelector) putCluster(cluster Cluster, clusterPath string) {
+	s.graph.plannedChanges.clusters[clusterPath] = clusterInfo{
+		name:        cluster.Name,
+		path:        clusterPath,
+		description: cluster.Description,
+	}
+	for _, item := range cluster.Items {
+		s.graph.plannedChanges.items[item.Name()] = itemChange{
+			itemName:    item.Name(),
+			newValue:    item,
+			clusterPath: clusterPath,
+		}
+	}
+	for _, subCluster := range cluster.SubClusters {
+		s.putCluster(subCluster, clusterPath+subCluster.Name+clusterPathSep)
+	}
+}
+
+// Del : Delete entire cluster with all items and sub-clusters it contains.
+func (s *clusterSelector) Del() {
+	firstNode := s.graph.findNodeIndex("", s.clusterPath)
+	for i := firstNode; i < len(s.graph.sortedNodes); i++ {
+		node := s.graph.sortedNodes[i]
+		if !strings.HasPrefix(node.clusterPath, s.clusterPath) {
+			break
+		}
+		s.graph.plannedChanges.items[node.name] = itemChange{
+			itemName:    node.name,
+			newValue:    nil, // delete
+			clusterPath: node.clusterPath,
+		}
+	}
+}
+
+// Get : Get summary info for all items in the cluster from DepGraph.
+// This summary corresponds to the state after the last Sync().
+func (s *clusterSelector) Get() (clusterSummary ClusterSummary, exists bool) {
+	_, exists = s.graph.clusters[s.clusterPath]
+	if !exists {
+		return ClusterSummary{}, false
+	}
+	firstNode := s.graph.findNodeIndex("", s.clusterPath)
+	clusterSummary, _ = s.getClusterSummary(s.clusterPath, firstNode)
+	return clusterSummary, true
+}
+
+func (s *clusterSelector) getClusterSummary(clusterPath string, firstNode int) (
+	clusterSummary ClusterSummary, nodeAfter int) {
+
+	cluster, exists := s.graph.clusters[clusterPath]
+	if !exists {
+		panic(
+			fmt.Sprintf("info for cluster %s should be available",
+				s.clusterPath))
+	}
+	clusterSummary.Name = cluster.name
+	clusterSummary.Description = cluster.description
+	clusterSummary.ClusterPath = cluster.path
+	i := firstNode
+	for i < len(s.graph.nodes) {
+		node := s.graph.sortedNodes[i]
+		if !strings.HasPrefix(node.clusterPath, clusterPath) {
+			break
+		}
+		if node.clusterPath == clusterPath {
+			clusterSummary.Items = append(clusterSummary.Items,
+				nodeToItemSummary(node))
+			i++
+			continue
+		}
+		// item is from a sub-cluster
+		suffix := node.clusterPath[len(clusterPath):]
+		nextSep := strings.Index(suffix, clusterPathSep)
+		if nextSep == -1 {
+			panic(fmt.Sprintf("invalid cluster path: %s", node.clusterPath))
+		}
+		subClusterPath := node.clusterPath[:len(clusterPath)+nextSep+len(clusterPathSep)]
+		var subCluster ClusterSummary
+		subCluster, i = s.getClusterSummary(subClusterPath, i)
+		clusterSummary.SubClusters = append(clusterSummary.SubClusters, subCluster)
+	}
+	return clusterSummary, i
+}
+
+// Put : Create/Modify item.
+func (s *itemSelector) Put(item Item) {
+	if s.itemName != item.Name() {
+		panic("item name mismatch")
+	}
+	s.graph.plannedChanges.items[s.itemName] = itemChange{
+		itemName:    s.itemName,
+		newValue:    item,
+		clusterPath: s.clusterPath,
+	}
+}
+
+// Del : Delete item.
+func (s *itemSelector) Del() {
+	s.graph.plannedChanges.items[s.itemName] = itemChange{
+		itemName:    s.itemName,
+		newValue:    nil, // delete
+		clusterPath: s.clusterPath,
+	}
+}
+
+// Get : Get summary info for the item from DepGraph.
+// This summary corresponds to the item state after the last Sync().
+func (s *itemSelector) Get() (itemSummary ItemSummary, exists bool) {
+	var node *node
+	node, exists = s.graph.nodes[s.itemName]
+	if !exists || !strings.HasPrefix(node.clusterPath, s.clusterPath) {
+		return ItemSummary{}, false
+	}
+	return nodeToItemSummary(node), true
+}
+
+func nodeToItemSummary(node *node) ItemSummary {
+	return ItemSummary{
+		Item:        node.value,
+		State:       node.state,
+		LastOp:      node.lastOp,
+		LastError:   node.lastErr,
+		ClusterPath: node.clusterPath,
+	}
+}

--- a/pkg/pillar/depgraph/depgraph_stack.go
+++ b/pkg/pillar/depgraph/depgraph_stack.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2021 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// A simple stack of planned (not yet sync-ed) item changes.
+
+package depgraph
+
+import "fmt"
+
+// Changes not yet submitted with Sync().
+type plannedChanges struct {
+	items    map[string]itemChange  // key = item name
+	clusters map[string]clusterInfo // key = cluster path; nodeCount not used here
+}
+
+type itemChange struct {
+	itemName    string
+	newValue    Item // nil represents Del operation
+	clusterPath string
+}
+
+// Item inserted into the stack for processing inside DepGraph.Sync().
+type stackedItem struct {
+	itemName  string
+	postOrder bool
+}
+
+// stack is a simple LIFO queue for item changes.
+type stack struct {
+	itemChanges []stackedItem
+}
+
+// newStack : returns a new instance of the stack.
+func newStack() *stack {
+	return &stack{
+		itemChanges: make([]stackedItem, 0, 16),
+	}
+}
+
+// isEmpty : will return a boolean indicating whether there are any elements on the stack.
+func (s *stack) isEmpty() bool {
+	return len(s.itemChanges) == 0
+}
+
+// push : Adds an element on the stack.
+func (s *stack) push(item stackedItem) *stack {
+	s.itemChanges = append(s.itemChanges, item)
+	return s
+}
+
+// pop : removes an element from the stack and returns its value.
+func (s *stack) pop() (stackedItem, error) {
+	if len(s.itemChanges) == 0 {
+		return stackedItem{}, fmt.Errorf("stack is empty")
+	}
+	element := s.itemChanges[len(s.itemChanges)-1]
+	s.itemChanges = s.itemChanges[:len(s.itemChanges)-1]
+	return element, nil
+}

--- a/pkg/pillar/depgraph/depgraph_test.go
+++ b/pkg/pillar/depgraph/depgraph_test.go
@@ -1,0 +1,1463 @@
+// Copyright (c) 2021 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package depgraph_test
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/depgraph"
+)
+
+type testCtx struct {
+	graph  depgraph.DepGraph
+	opsLog *operationsLog
+}
+
+func newTestCtx(graph depgraph.DepGraph) *testCtx {
+	return &testCtx{
+		graph:  graph,
+		opsLog: &operationsLog{},
+	}
+}
+
+func (ctx *testCtx) syncGraph() error {
+	ctx.opsLog.clear()
+	return ctx.graph.Sync(context.Background())
+}
+
+func (ctx *testCtx) addConfigurator(forItemType string, itemDepsClb mockItemDepsClb) error {
+	return ctx.graph.RegisterConfigurator(&mockConfigurator{
+		itemType:    forItemType,
+		opsLog:      ctx.opsLog,
+		itemDepsClb: itemDepsClb,
+	}, forItemType)
+}
+
+func (ctx *testCtx) executedOps() []opLog {
+	return ctx.opsLog.log
+}
+
+// test context is accessed by matchers (see depgraph_matchers_test.go).
+var ctx *testCtx
+var log = base.NewSourceLogObject(logrus.StandardLogger(), "test", 0)
+
+// Items: A, B, C
+// Without dependencies
+func TestItemsWithoutDependencies(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx = newTestCtx(depgraph.NewDepGraph(log))
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(ctx.executedOps()).To(BeEmpty())
+
+	itemA := mockItem{
+		name:            "A",
+		itemType:        "type1",
+		modifiableAttrs: mockItemAttrs{intAttr: 10, strAttr: "abc"},
+	}
+	itemB := mockItem{
+		name:            "B",
+		itemType:        "type1",
+		modifiableAttrs: mockItemAttrs{boolAttr: true},
+	}
+	itemC := mockItem{
+		name:     "C",
+		itemType: "type2",
+	}
+	g.Expect(ctx.addConfigurator("type1", nil)).To(Succeed())
+	g.Expect(ctx.addConfigurator("type2", nil)).To(Succeed())
+
+	// 1. Create all three items
+	ctx.graph.Item(itemA.name).Put(itemA)
+	ctx.graph.Item(itemB.name).Put(itemB)
+	ctx.graph.Item(itemC.name).Put(itemC)
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemA).To(BeCreated())
+	g.Expect(itemB).To(BeCreated())
+	g.Expect(itemC).To(BeCreated())
+	g.Expect(ctx.executedOps()).To(HaveLen(3))
+
+	summary, exists := ctx.graph.Item(itemA.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.Item).To(BeEquivalentTo(itemA))
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+
+	// 2. Modify itemB
+	itemB.modifiableAttrs.intAttr++
+	ctx.graph.Item(itemB.name).Put(itemB)
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemB).To(BeModified())
+	g.Expect(ctx.executedOps()).To(HaveLen(1))
+
+	summary, exists = ctx.graph.Item(itemB.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.Item).To(BeEquivalentTo(itemB))
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationModify))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+
+	// 3. Put the same itemB, should not trigger Modify
+	ctx.graph.Item(itemB.name).Put(itemB)
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemB).ToNot(BeModified())
+	g.Expect(ctx.executedOps()).To(BeEmpty())
+
+	// 4. Delete itemA and itemC
+	ctx.graph.Item(itemA.name).Del()
+	ctx.graph.Item(itemC.name).Del()
+
+	// not applied until Sync is called
+	summary, exists = ctx.graph.Item(itemA.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemA).To(BeDeleted())
+	g.Expect(itemB).ToNot(BeDeleted())
+	g.Expect(itemC).To(BeDeleted())
+	g.Expect(ctx.executedOps()).To(HaveLen(2))
+
+	summary, exists = ctx.graph.Item(itemA.name).Get()
+	g.Expect(exists).To(BeFalse())
+	summary, exists = ctx.graph.Item(itemB.name).Get()
+	g.Expect(exists).To(BeTrue())
+	summary, exists = ctx.graph.Item(itemC.name).Get()
+	g.Expect(exists).To(BeFalse())
+}
+
+func depFromStrAttr(_, modifiableAttrs mockItemAttrs) []depgraph.Dependency {
+	return []depgraph.Dependency{
+		&depgraph.ItemIsCreated{
+			ItemName:    modifiableAttrs.strAttr,
+			Description: "dependency for testing",
+		},
+	}
+}
+
+func depFromStrAttrWithRecreate(_, modifiableAttrs mockItemAttrs) []depgraph.Dependency {
+	return []depgraph.Dependency{
+		&depgraph.ItemIsCreated{
+			ItemName:             modifiableAttrs.strAttr,
+			RecreateWhenModified: true,
+			Description:          "dependency for testing",
+		},
+	}
+}
+
+func depFromSliceAttr(_, modifiableAttrs mockItemAttrs) (deps []depgraph.Dependency) {
+	for _, item := range modifiableAttrs.sliceAttr {
+		deps = append(deps, &depgraph.ItemIsCreated{
+			ItemName:    item,
+			Description: "dependency for testing",
+		})
+	}
+	return deps
+}
+
+// Items: A, B, C
+// Dependencies: A->C, B->C
+func TestDependencyItemIsCreated(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx = newTestCtx(depgraph.NewDepGraph(log))
+
+	itemA := mockItem{
+		name:     "A",
+		itemType: "type1",
+		modifiableAttrs: mockItemAttrs{
+			// simulate reference to a dependency
+			strAttr: "C",
+		},
+	}
+	itemB := mockItem{
+		name:     "B",
+		itemType: "type1",
+		modifiableAttrs: mockItemAttrs{
+			// simulate reference to a dependency
+			strAttr: "C",
+		},
+	}
+	itemC := mockItem{
+		name:     "C",
+		itemType: "type2",
+	}
+
+	g.Expect(ctx.addConfigurator("type1", depFromStrAttr)).To(Succeed())
+	g.Expect(ctx.addConfigurator("type2", nil)).To(Succeed())
+
+	// 1. Create all three items
+	ctx.graph.Item(itemA.name).Put(itemA)
+	ctx.graph.Item(itemB.name).Put(itemB)
+	ctx.graph.Item(itemC.name).Put(itemC)
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemA).To(BeCreated().After(itemC))
+	g.Expect(itemB).To(BeCreated().After(itemC))
+	g.Expect(itemC).To(BeCreated())
+	g.Expect(ctx.executedOps()).To(HaveLen(3))
+
+	summary, exists := ctx.graph.Item(itemA.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.Item).To(BeEquivalentTo(itemA))
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+	summary, exists = ctx.graph.Item(itemB.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.Item).To(BeEquivalentTo(itemB))
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+	summary, exists = ctx.graph.Item(itemC.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.Item).To(BeEquivalentTo(itemC))
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+
+	// 2. Modify itemC, dependent items A and B should remain unchanged
+	//    (ItemIsCreated.RecreateWhenModified is not set)
+	itemC.modifiableAttrs.boolAttr = true
+	ctx.graph.Item(itemC.name).Put(itemC)
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemC).To(BeModified())
+	g.Expect(ctx.executedOps()).To(HaveLen(1))
+
+	// 2. Delete itemC, dependent items A and B should be removed and marked as pending
+	ctx.graph.Item(itemC.name).Del()
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemA).To(BeDeleted().Before(itemC))
+	g.Expect(itemB).To(BeDeleted().Before(itemC))
+	g.Expect(itemC).To(BeDeleted())
+	g.Expect(ctx.executedOps()).To(HaveLen(3))
+
+	summary, exists = ctx.graph.Item(itemC.name).Get()
+	g.Expect(exists).To(BeFalse())
+
+	summary, exists = ctx.graph.Item(itemA.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationDelete))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStatePending))
+	summary, exists = ctx.graph.Item(itemB.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationDelete))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStatePending))
+}
+
+// Items: A, B, C
+// Dependencies: A->C, B->C (with RecreateWhenModified)
+func TestRecreateWhenModified(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx = newTestCtx(depgraph.NewDepGraph(log))
+
+	itemA := mockItem{
+		name:     "A",
+		itemType: "type1",
+		modifiableAttrs: mockItemAttrs{
+			// simulate reference to a dependency
+			strAttr: "C",
+		},
+	}
+	itemB := mockItem{
+		name:     "B",
+		itemType: "type1",
+		modifiableAttrs: mockItemAttrs{
+			// simulate reference to a dependency
+			strAttr: "C",
+		},
+	}
+	itemC := mockItem{
+		name:     "C",
+		itemType: "type2",
+	}
+
+	g.Expect(ctx.addConfigurator("type1", depFromStrAttrWithRecreate)).To(Succeed())
+	g.Expect(ctx.addConfigurator("type2", nil)).To(Succeed())
+
+	// 1. Create all three items
+	ctx.graph.Item(itemA.name).Put(itemA)
+	ctx.graph.Item(itemB.name).Put(itemB)
+	ctx.graph.Item(itemC.name).Put(itemC)
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemA).To(BeCreated().After(itemC))
+	g.Expect(itemB).To(BeCreated().After(itemC))
+	g.Expect(itemC).To(BeCreated())
+	g.Expect(ctx.executedOps()).To(HaveLen(3))
+
+	// 2. Modify itemC, dependent items A and B should be re-created
+	//    (ItemIsCreated.RecreateWhenModified is set)
+	itemC.modifiableAttrs.boolAttr = true
+	ctx.graph.Item(itemC.name).Put(itemC)
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemA).To(BeRecreated())
+	g.Expect(itemB).To(BeRecreated())
+	g.Expect(itemA).To(BeDeleted().Before(itemC).IsModified())
+	g.Expect(itemA).To(BeCreated().After(itemC).IsModified())
+	g.Expect(itemB).To(BeDeleted().Before(itemC).IsModified())
+	g.Expect(itemB).To(BeCreated().After(itemC).IsModified())
+	g.Expect(itemC).To(BeModified())
+	// Recreate = 2 ops (Delete + Create)
+	g.Expect(ctx.executedOps()).To(HaveLen(5))
+
+	summary, exists := ctx.graph.Item(itemA.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationRecreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+	summary, exists = ctx.graph.Item(itemB.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationRecreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+	summary, exists = ctx.graph.Item(itemC.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationModify))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+
+	// 3. Put the same itemC, should not trigger Modify or Recreate
+	ctx.graph.Item(itemC.name).Put(itemC)
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemA).ToNot(BeRecreated())
+	g.Expect(itemB).ToNot(BeRecreated())
+	g.Expect(itemC).ToNot(BeModified())
+	g.Expect(ctx.executedOps()).To(BeEmpty())
+}
+
+// Items: A, B
+// Dependencies: A->B
+// Scenario: re-create of B should be surrounded by delete+create of A
+func TestRecreate(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx = newTestCtx(depgraph.NewDepGraph(log))
+
+	itemA := mockItem{
+		name:     "A",
+		itemType: "type1",
+		modifiableAttrs: mockItemAttrs{
+			// simulate reference to a dependency
+			strAttr: "B",
+		},
+	}
+	itemB := mockItem{
+		name:     "B",
+		itemType: "type2",
+		staticAttrs: mockItemAttrs{
+			intAttr: 10,
+		},
+	}
+
+	g.Expect(ctx.addConfigurator("type1", depFromStrAttr)).To(Succeed())
+	g.Expect(ctx.addConfigurator("type2", nil)).To(Succeed())
+
+	// 1. Create both items
+	ctx.graph.Item(itemA.name).Put(itemA)
+	ctx.graph.Item(itemB.name).Put(itemB)
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemA).To(BeCreated().After(itemB))
+	g.Expect(itemB).To(BeCreated())
+	g.Expect(ctx.executedOps()).To(HaveLen(2))
+
+	// 2. Make modification to itemB which requires re-create
+	itemB.staticAttrs.intAttr++
+	ctx.graph.Item(itemB.name).Put(itemB)
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemA).To(BeDeleted().Before(itemB).IsRecreated())
+	g.Expect(itemB).To(BeRecreated())
+	g.Expect(itemA).To(BeCreated().After(itemB).IsRecreated())
+	g.Expect(ctx.executedOps()).To(HaveLen(4))
+
+	summary, exists := ctx.graph.Item(itemA.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+	summary, exists = ctx.graph.Item(itemB.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationRecreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+}
+
+// Items: A, B, C
+// Dependencies: A->B->C
+func TestTransitiveDependencies(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx = newTestCtx(depgraph.NewDepGraph(log))
+
+	itemA := mockItem{
+		name:     "A",
+		itemType: "type1",
+		modifiableAttrs: mockItemAttrs{
+			// simulate reference to a dependency
+			strAttr: "B",
+		},
+	}
+	itemB := mockItem{
+		name:     "B",
+		itemType: "type2",
+		modifiableAttrs: mockItemAttrs{
+			// simulate reference to a dependency
+			strAttr: "C",
+		},
+	}
+	itemC := mockItem{
+		name:     "C",
+		itemType: "type3",
+	}
+
+	g.Expect(ctx.addConfigurator("type1", depFromStrAttr)).To(Succeed())
+	g.Expect(ctx.addConfigurator("type2", depFromStrAttr)).To(Succeed())
+	g.Expect(ctx.addConfigurator("type3", nil)).To(Succeed())
+
+	// 1. Try to create only itemA and itemB at first
+	ctx.graph.Item(itemA.name).Put(itemA)
+	ctx.graph.Item(itemB.name).Put(itemB)
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemA).ToNot(BeCreated())
+	g.Expect(itemB).ToNot(BeCreated())
+	g.Expect(ctx.executedOps()).To(BeEmpty())
+
+	summary, exists := ctx.graph.Item(itemA.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationUnknown))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStatePending))
+	summary, exists = ctx.graph.Item(itemB.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationUnknown))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStatePending))
+
+	// 2. Now create itemC; itemA should be created transitively
+	ctx.graph.Item(itemC.name).Put(itemC)
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemA).To(BeCreated().After(itemB))
+	g.Expect(itemB).To(BeCreated().After(itemC))
+	g.Expect(itemC).To(BeCreated())
+	g.Expect(ctx.executedOps()).To(HaveLen(3))
+
+	summary, exists = ctx.graph.Item(itemA.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+	summary, exists = ctx.graph.Item(itemB.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+	summary, exists = ctx.graph.Item(itemC.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+
+	// 3. Delete itemC, both itemA and itemB should be removed and marked as pending
+	ctx.graph.Item(itemC.name).Del()
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemA).To(BeDeleted().Before(itemB))
+	g.Expect(itemB).To(BeDeleted().Before(itemC))
+	g.Expect(itemC).To(BeDeleted())
+	g.Expect(ctx.executedOps()).To(HaveLen(3))
+
+	summary, exists = ctx.graph.Item(itemA.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationDelete))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStatePending))
+	summary, exists = ctx.graph.Item(itemB.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationDelete))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStatePending))
+	summary, exists = ctx.graph.Item(itemC.name).Get()
+	g.Expect(exists).To(BeFalse())
+}
+
+// Items: A, B
+// Dependencies: A->B, A->C (but C is never created)
+func TestUnsatisfiedDependency(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx = newTestCtx(depgraph.NewDepGraph(log))
+
+	itemA := mockItem{
+		name:     "A",
+		itemType: "type1",
+		modifiableAttrs: mockItemAttrs{
+			// simulate references to a dependency
+			sliceAttr: []string{"B", "C"},
+		},
+	}
+	itemB := mockItem{
+		name:     "B",
+		itemType: "type2",
+	}
+
+	g.Expect(ctx.addConfigurator("type1", depFromSliceAttr)).To(Succeed())
+	g.Expect(ctx.addConfigurator("type2", nil)).To(Succeed())
+
+	// 1. Create both items; itemA will remain pending
+	ctx.graph.Item(itemA.name).Put(itemA)
+	ctx.graph.Item(itemB.name).Put(itemB)
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemA).ToNot(BeCreated())
+	g.Expect(itemB).To(BeCreated())
+	g.Expect(ctx.executedOps()).To(HaveLen(1))
+
+	summary, exists := ctx.graph.Item(itemA.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationUnknown))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStatePending))
+	summary, exists = ctx.graph.Item(itemB.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+
+	// 2. Remove both items, NOOP for itemA
+	ctx.graph.Item(itemA.name).Del()
+	ctx.graph.Item(itemB.name).Del()
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemA).ToNot(BeDeleted())
+	g.Expect(itemB).To(BeDeleted())
+	g.Expect(ctx.executedOps()).To(HaveLen(1))
+
+	summary, exists = ctx.graph.Item(itemA.name).Get()
+	g.Expect(exists).To(BeFalse())
+	summary, exists = ctx.graph.Item(itemB.name).Get()
+	g.Expect(exists).To(BeFalse())
+}
+
+// Items: A, B
+// Dependencies: A->B (with MustSatisfy defined to check the content of B)
+func TestMustSatisfy(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx = newTestCtx(depgraph.NewDepGraph(log))
+
+	const magicValue = 42
+	itemA := mockItem{
+		name:     "A",
+		itemType: "type1",
+		modifiableAttrs: mockItemAttrs{
+			// simulate reference to a dependency
+			strAttr: "B",
+			// dependency must have this attribute
+			intAttr: magicValue,
+		},
+	}
+	itemB := mockItem{
+		name:     "B",
+		itemType: "type2",
+	}
+
+	depWithMustSatisfy := func(_, modifiableAttrs mockItemAttrs) []depgraph.Dependency {
+		return []depgraph.Dependency{
+			&depgraph.ItemIsCreated{
+				ItemName: modifiableAttrs.strAttr,
+				MustSatisfy: func(item depgraph.Item) bool {
+					return modifiableAttrs.intAttr == item.(mockItem).modifiableAttrs.intAttr
+				},
+			},
+		}
+	}
+
+	g.Expect(ctx.addConfigurator("type1", depWithMustSatisfy)).To(Succeed())
+	g.Expect(ctx.addConfigurator("type2", nil)).To(Succeed())
+
+	// 1. Create both items; itemA will remain pending (MustSatisfy returns false for itemB)
+	ctx.graph.Item(itemA.name).Put(itemA)
+	ctx.graph.Item(itemB.name).Put(itemB)
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemA).ToNot(BeCreated())
+	g.Expect(itemB).To(BeCreated())
+	g.Expect(ctx.executedOps()).To(HaveLen(1))
+
+	summary, exists := ctx.graph.Item(itemA.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationUnknown))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStatePending))
+	summary, exists = ctx.graph.Item(itemB.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+
+	// 2. Modify itemB, it should now satisfy itemA dependency
+	itemB.modifiableAttrs.intAttr = magicValue
+	ctx.graph.Item(itemB.name).Put(itemB)
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemA).To(BeCreated().After(itemB).IsModified())
+	g.Expect(itemB).To(BeModified())
+	g.Expect(ctx.executedOps()).To(HaveLen(2))
+
+	summary, exists = ctx.graph.Item(itemA.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+	summary, exists = ctx.graph.Item(itemB.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationModify))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+}
+
+// 3 scenarios where dependencies change with Modify.
+func TestModifiedDependencies(t *testing.T) {
+	// Scenario 1
+	// Items: A, B, C
+	// Dependencies: initially A->B, then A->C
+	g := NewGomegaWithT(t)
+	ctx = newTestCtx(depgraph.NewDepGraph(log))
+
+	itemA := mockItem{
+		name:     "A",
+		itemType: "type1",
+		modifiableAttrs: mockItemAttrs{
+			// simulate reference to a dependency
+			strAttr: "B",
+		},
+	}
+	itemB := mockItem{
+		name:     "B",
+		itemType: "type2",
+	}
+	itemC := mockItem{
+		name:     "C",
+		itemType: "type2",
+	}
+
+	g.Expect(ctx.addConfigurator("type1", depFromStrAttr)).To(Succeed())
+	g.Expect(ctx.addConfigurator("type2", nil)).To(Succeed())
+
+	// 1.1 Create itemA and itemB at first
+	ctx.graph.Item(itemA.name).Put(itemA)
+	ctx.graph.Item(itemB.name).Put(itemB)
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemA).To(BeCreated().After(itemB))
+	g.Expect(itemB).To(BeCreated())
+	g.Expect(ctx.executedOps()).To(HaveLen(2))
+
+	summary, exists := ctx.graph.Item(itemA.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+	summary, exists = ctx.graph.Item(itemB.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+
+	// 1.2. Modify itemA such then it now depends on non-existing itemC
+	itemA.modifiableAttrs.strAttr = "C"
+	ctx.graph.Item(itemA.name).Put(itemA)
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemA).To(BeDeleted())
+	g.Expect(ctx.executedOps()).To(HaveLen(1))
+
+	summary, exists = ctx.graph.Item(itemA.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationDelete))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStatePending))
+
+	// 1.3 Create itemC and the pending itemA
+	ctx.graph.Item(itemC.name).Put(itemC)
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemA).To(BeCreated().After(itemC))
+	g.Expect(itemC).To(BeCreated())
+	g.Expect(ctx.executedOps()).To(HaveLen(2))
+
+	summary, exists = ctx.graph.Item(itemA.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+	summary, exists = ctx.graph.Item(itemC.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+
+	// 1.4 Remove itemB; should have no effect on itemA
+	ctx.graph.Item(itemB.name).Del()
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemA).ToNot(BeDeleted())
+	g.Expect(itemB).To(BeDeleted())
+	g.Expect(ctx.executedOps()).To(HaveLen(1))
+
+	summary, exists = ctx.graph.Item(itemA.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+	summary, exists = ctx.graph.Item(itemB.name).Get()
+	g.Expect(exists).To(BeFalse())
+
+	// Scenario 2
+	// Items: A, B - changed to A', B'
+	// Dependencies: A->B, then A'->B' (A must be recreated, there is no other way)
+	ctx = newTestCtx(depgraph.NewDepGraph(log))
+
+	itemA = mockItem{
+		name:     "A",
+		itemType: "type1",
+		modifiableAttrs: mockItemAttrs{
+			// simulate reference to a dependency
+			strAttr: "B",
+			// dependency must have this attribute
+			intAttr: 1,
+		},
+	}
+	itemB = mockItem{
+		name:     "B",
+		itemType: "type2",
+		modifiableAttrs: mockItemAttrs{
+			intAttr: 1,
+		},
+	}
+
+	depWithMustSatisfy := func(_, modifiableAttrs mockItemAttrs) []depgraph.Dependency {
+		return []depgraph.Dependency{
+			&depgraph.ItemIsCreated{
+				ItemName: modifiableAttrs.strAttr,
+				MustSatisfy: func(item depgraph.Item) bool {
+					return modifiableAttrs.intAttr == item.(mockItem).modifiableAttrs.intAttr
+				},
+			},
+		}
+	}
+
+	g.Expect(ctx.addConfigurator("type1", depWithMustSatisfy)).To(Succeed())
+	g.Expect(ctx.addConfigurator("type2", nil)).To(Succeed())
+
+	// 2.1. Create both items
+	ctx.graph.Item(itemA.name).Put(itemA)
+	ctx.graph.Item(itemB.name).Put(itemB)
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemA).To(BeCreated())
+	g.Expect(itemB).To(BeCreated())
+	g.Expect(ctx.executedOps()).To(HaveLen(2))
+
+	summary, exists = ctx.graph.Item(itemA.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+	summary, exists = ctx.graph.Item(itemB.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+
+	// 2.2. Modify both items - dependencies are also updated
+	// However, because modifications are done one after the other, itemA will be recreated.
+	itemA.modifiableAttrs.intAttr = 2
+	itemB.modifiableAttrs.intAttr = 2
+	ctx.graph.Item(itemA.name).Put(itemA)
+	ctx.graph.Item(itemB.name).Put(itemB)
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemA).To(BeRecreated())
+	g.Expect(itemA).To(BeDeleted().Before(itemB).IsModified())
+	g.Expect(itemA).To(BeCreated().After(itemB).IsModified())
+	g.Expect(itemB).To(BeModified())
+	g.Expect(ctx.executedOps()).To(HaveLen(3))
+
+	summary, exists = ctx.graph.Item(itemA.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+	summary, exists = ctx.graph.Item(itemB.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationModify))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+
+	// Scenario 3
+	// Items: initially A, B, C; later A' (modified A) and C (B removed)
+	// Dependencies: A->B, A'->C
+	ctx = newTestCtx(depgraph.NewDepGraph(log))
+
+	itemA = mockItem{
+		name:     "A",
+		itemType: "type1",
+		modifiableAttrs: mockItemAttrs{
+			// simulate reference to a dependency
+			strAttr: "B",
+		},
+	}
+	itemB = mockItem{
+		name:     "B",
+		itemType: "type2",
+	}
+	itemC = mockItem{
+		name:     "C",
+		itemType: "type2",
+	}
+
+	g.Expect(ctx.addConfigurator("type1", depFromStrAttr)).To(Succeed())
+	g.Expect(ctx.addConfigurator("type2", nil)).To(Succeed())
+
+	// 3.1. Create all items
+	ctx.graph.Item(itemA.name).Put(itemA)
+	ctx.graph.Item(itemB.name).Put(itemB)
+	ctx.graph.Item(itemC.name).Put(itemC)
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemA).To(BeCreated().After(itemB))
+	g.Expect(itemB).To(BeCreated())
+	g.Expect(itemC).To(BeCreated())
+	g.Expect(ctx.executedOps()).To(HaveLen(3))
+
+	summary, exists = ctx.graph.Item(itemA.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+	summary, exists = ctx.graph.Item(itemB.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+	summary, exists = ctx.graph.Item(itemC.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+
+	// 3.2. Delete itemB but also modify itemA to depend on itemC now
+	itemA.modifiableAttrs.strAttr = "C"
+	ctx.graph.Item(itemA.name).Put(itemA)
+	ctx.graph.Item(itemB.name).Del()
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemA).To(BeModified().Before(itemB).IsDeleted())
+	g.Expect(itemB).To(BeDeleted())
+	g.Expect(ctx.executedOps()).To(HaveLen(2))
+
+	summary, exists = ctx.graph.Item(itemA.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationModify))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+	summary, exists = ctx.graph.Item(itemB.name).Get()
+	g.Expect(exists).To(BeFalse())
+	summary, exists = ctx.graph.Item(itemC.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+}
+
+// Items (clustered): [A, B, [C, D]]
+// Dependencies: C->A, D->B
+func TestClusters(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx = newTestCtx(depgraph.NewDepGraph(log))
+
+	itemA := mockItem{
+		name:     "A",
+		itemType: "type1",
+	}
+	itemB := mockItem{
+		name:     "B",
+		itemType: "type1",
+	}
+	itemC := mockItem{
+		name:     "C",
+		itemType: "type2",
+		modifiableAttrs: mockItemAttrs{
+			// simulate reference to a dependency
+			strAttr: "A",
+		},
+	}
+	itemD := mockItem{
+		name:     "D",
+		itemType: "type2",
+		modifiableAttrs: mockItemAttrs{
+			// simulate reference to a dependency
+			strAttr: "B",
+		},
+	}
+
+	g.Expect(ctx.addConfigurator("type1", nil)).To(Succeed())
+	g.Expect(ctx.addConfigurator("type2", depFromStrAttr)).To(Succeed())
+
+	// 1. Create clusters
+	var nestedClusterDescr = "Nested cluster"
+	nestedCluster := depgraph.Cluster{
+		Name:        "nested-cluster",
+		Description: nestedClusterDescr,
+		Items:       []depgraph.Item{itemC, itemD},
+		SubClusters: nil,
+	}
+	var clusterDescr = "cluster with itemA, itemB and one nested cluster"
+	cluster := depgraph.Cluster{
+		Name:        "cluster",
+		Description: clusterDescr,
+		Items:       []depgraph.Item{itemA, itemB},
+		SubClusters: []depgraph.Cluster{nestedCluster},
+	}
+	ctx.graph.Cluster(cluster.Name).Put(cluster)
+
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemA).To(BeCreated())
+	g.Expect(itemB).To(BeCreated())
+	g.Expect(itemC).To(BeCreated().After(itemA))
+	g.Expect(itemD).To(BeCreated().After(itemB))
+	g.Expect(ctx.executedOps()).To(HaveLen(4))
+
+	summary, exists := ctx.graph.Item(itemA.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+	g.Expect(summary.ClusterPath).To(Equal("/cluster/"))
+	summary, exists = ctx.graph.Item(itemB.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+	g.Expect(summary.ClusterPath).To(Equal("/cluster/"))
+	summary, exists = ctx.graph.Item(itemC.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+	g.Expect(summary.ClusterPath).To(Equal("/cluster/nested-cluster/"))
+	summary, exists = ctx.graph.Item(itemD.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+	g.Expect(summary.ClusterPath).To(Equal("/cluster/nested-cluster/"))
+
+	clusterSummary, exists := ctx.graph.Cluster(cluster.Name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(clusterSummary.Name).To(Equal(cluster.Name))
+	g.Expect(clusterSummary.Description).To(Equal(clusterDescr))
+	g.Expect(clusterSummary.ClusterPath).To(Equal("/cluster/"))
+	g.Expect(clusterSummary.Items).To(HaveLen(2))
+	g.Expect(clusterSummary.Items[0].Item.Name()).To(Equal(itemA.name))
+	g.Expect(clusterSummary.Items[1].Item.Name()).To(Equal(itemB.name))
+	g.Expect(clusterSummary.SubClusters).To(HaveLen(1))
+	g.Expect(clusterSummary.SubClusters[0].Name).To(Equal(nestedCluster.Name))
+	g.Expect(clusterSummary.SubClusters[0].Description).To(Equal(nestedClusterDescr))
+	g.Expect(clusterSummary.SubClusters[0].Items).To(HaveLen(2))
+	g.Expect(clusterSummary.SubClusters[0].Items[0].Item.Name()).To(Equal(itemC.name))
+	g.Expect(clusterSummary.SubClusters[0].Items[1].Item.Name()).To(Equal(itemD.name))
+
+	// 2. Change (replace) content of the cluster
+	itemA.staticAttrs.boolAttr = true
+	cluster.Items = []depgraph.Item{itemA}
+	clusterDescr = "cluster with itemA and one nested cluster"
+	cluster.Description = clusterDescr
+	ctx.graph.Cluster(cluster.Name).Put(cluster)
+
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemA).To(BeRecreated())
+	g.Expect(itemB).To(BeDeleted())
+	g.Expect(itemC).To(BeRecreated())
+	g.Expect(itemC).To(BeDeleted().Before(itemA).IsRecreated())
+	g.Expect(itemC).To(BeCreated().After(itemA).IsRecreated())
+	g.Expect(itemD).To(BeDeleted().Before(itemB).IsDeleted())
+	g.Expect(ctx.executedOps()).To(HaveLen(6))
+
+	summary, exists = ctx.graph.Item(itemA.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationRecreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+	g.Expect(summary.ClusterPath).To(Equal("/cluster/"))
+	summary, exists = ctx.graph.Item(itemB.name).Get()
+	g.Expect(exists).To(BeFalse())
+	summary, exists = ctx.graph.Item(itemC.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+	g.Expect(summary.ClusterPath).To(Equal("/cluster/nested-cluster/"))
+	summary, exists = ctx.graph.Item(itemD.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationDelete))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStatePending))
+	g.Expect(summary.ClusterPath).To(Equal("/cluster/nested-cluster/"))
+
+	clusterSummary, exists = ctx.graph.Cluster(cluster.Name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(clusterSummary.Name).To(Equal(cluster.Name))
+	g.Expect(clusterSummary.Description).To(Equal(clusterDescr))
+	g.Expect(clusterSummary.ClusterPath).To(Equal("/cluster/"))
+	g.Expect(clusterSummary.Items).To(HaveLen(1))
+	g.Expect(clusterSummary.Items[0].Item.Name()).To(Equal(itemA.name))
+	g.Expect(clusterSummary.SubClusters).To(HaveLen(1))
+	g.Expect(clusterSummary.SubClusters[0].Name).To(Equal(nestedCluster.Name))
+	g.Expect(clusterSummary.SubClusters[0].Description).To(Equal(nestedClusterDescr))
+	g.Expect(clusterSummary.SubClusters[0].Items).To(HaveLen(2))
+	g.Expect(clusterSummary.SubClusters[0].Items[0].Item.Name()).To(Equal(itemC.name))
+	g.Expect(clusterSummary.SubClusters[0].Items[1].Item.Name()).To(Equal(itemD.name))
+
+	clusterSummary, exists = ctx.graph.Cluster(cluster.Name).Cluster(nestedCluster.Name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(clusterSummary.Description).To(Equal(nestedClusterDescr))
+	g.Expect(clusterSummary.ClusterPath).To(Equal("/cluster/nested-cluster/"))
+	g.Expect(clusterSummary.Items).To(HaveLen(2))
+	g.Expect(clusterSummary.Items[0].Item.Name()).To(Equal(itemC.name))
+	g.Expect(clusterSummary.Items[1].Item.Name()).To(Equal(itemD.name))
+	g.Expect(clusterSummary.SubClusters).To(HaveLen(0))
+
+	// 3. Apply the same content again
+	ctx.graph.Cluster(cluster.Name).Put(depgraph.Cluster{Name: "cluster"}) // overridden below
+	ctx.graph.Cluster(cluster.Name).Put(cluster)
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(ctx.executedOps()).To(BeEmpty())
+
+	// 4. Remove entire (nested) cluster
+	ctx.graph.Cluster(cluster.Name).Cluster(nestedCluster.Name).Del()
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemC).To(BeDeleted())
+	g.Expect(itemD).ToNot(BeDeleted()) // was pending
+	g.Expect(ctx.executedOps()).To(HaveLen(1))
+
+	clusterSummary, exists = ctx.graph.Cluster(cluster.Name).Get()
+	g.Expect(exists).To(BeTrue())
+	clusterSummary, exists = ctx.graph.Cluster(cluster.Name).Cluster(nestedCluster.Name).Get()
+	g.Expect(exists).To(BeFalse())
+
+	summary, exists = ctx.graph.Item(itemC.name).Get()
+	g.Expect(exists).To(BeFalse())
+	summary, exists = ctx.graph.Item(itemD.name).Get()
+	g.Expect(exists).To(BeFalse())
+
+	// 5. Access item through a cluster
+	summary, exists = ctx.graph.Cluster(cluster.Name).Item(itemA.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.Item.Name()).To(Equal(itemA.name))
+
+	// 6. Move itemA to another cluster (the top-level one)
+	ctx.graph.Item(itemA.name).Put(itemA)
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(ctx.executedOps()).To(BeEmpty())
+	summary, exists = ctx.graph.Cluster(cluster.Name).Item(itemA.name).Get()
+	g.Expect(exists).To(BeFalse())
+	summary, exists = ctx.graph.Item(itemA.name).Get()
+	g.Expect(exists).To(BeTrue())
+	// original cluster is no longer used and so it should be GCed
+	clusterSummary, exists = ctx.graph.Cluster(cluster.Name).Get()
+	g.Expect(exists).To(BeFalse())
+
+	// 7. Graph as a whole is the top-level cluster
+	clusterSummary, exists = ctx.graph.Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(clusterSummary.Name).To(BeEmpty())
+	g.Expect(clusterSummary.Description).To(BeEmpty())
+	g.Expect(clusterSummary.ClusterPath).To(Equal("/"))
+	g.Expect(clusterSummary.Items).To(HaveLen(1))
+	g.Expect(clusterSummary.Items[0].Item.Name()).To(Equal(itemA.name))
+	g.Expect(clusterSummary.SubClusters).To(HaveLen(0))
+}
+
+// Items: A, B, External (obviously external item)
+// Dependencies: A->External, B->External
+func TestExternalItems(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx = newTestCtx(depgraph.NewDepGraph(log))
+
+	itemA := mockItem{
+		name:     "A",
+		itemType: "type1",
+		modifiableAttrs: mockItemAttrs{
+			// simulate reference to a dependency
+			strAttr: "External",
+		},
+	}
+	itemB := mockItem{
+		name:     "B",
+		itemType: "type1",
+		modifiableAttrs: mockItemAttrs{
+			// simulate reference to a dependency
+			strAttr: "External",
+		},
+	}
+	itemExt := mockItem{
+		name:       "External",
+		itemType:   "type2",
+		isExternal: true,
+	}
+
+	g.Expect(ctx.addConfigurator("type1", depFromStrAttrWithRecreate)).To(Succeed())
+	// No configurator for type2 - those items are created externally
+
+	// 1. Try to create itemA and itemB; both will remain pending (waiting for external item)
+	ctx.graph.Item(itemA.name).Put(itemA)
+	ctx.graph.Item(itemB.name).Put(itemB)
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemA).ToNot(BeCreated())
+	g.Expect(itemB).ToNot(BeCreated())
+	g.Expect(ctx.executedOps()).To(BeEmpty())
+
+	summary, exists := ctx.graph.Item(itemA.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationUnknown))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStatePending))
+	summary, exists = ctx.graph.Item(itemB.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationUnknown))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStatePending))
+	summary, exists = ctx.graph.Item(itemExt.name).Get()
+	g.Expect(exists).To(BeFalse())
+
+	// 2. External item was created
+	ctx.graph.Item(itemExt.name).Put(itemExt)
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemA).To(BeCreated())
+	g.Expect(itemB).To(BeCreated())
+	g.Expect(ctx.executedOps()).To(HaveLen(2))
+
+	summary, exists = ctx.graph.Item(itemA.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+	summary, exists = ctx.graph.Item(itemB.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+	summary, exists = ctx.graph.Item(itemExt.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationUnknown)) // managed externally
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+
+	// 3. External item was modified
+	itemExt.modifiableAttrs.strAttr = "modified"
+	ctx.graph.Item(itemExt.name).Put(itemExt)
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemA).To(BeRecreated())
+	g.Expect(itemB).To(BeRecreated())
+	g.Expect(ctx.executedOps()).To(HaveLen(4))
+
+	summary, exists = ctx.graph.Item(itemA.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationRecreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+	summary, exists = ctx.graph.Item(itemB.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationRecreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+	summary, exists = ctx.graph.Item(itemExt.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationUnknown))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+
+	// 4. External item was deleted
+	ctx.graph.Item(itemExt.name).Del()
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemA).To(BeDeleted())
+	g.Expect(itemB).To(BeDeleted())
+	g.Expect(ctx.executedOps()).To(HaveLen(2))
+
+	summary, exists = ctx.graph.Item(itemA.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationDelete))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStatePending))
+	summary, exists = ctx.graph.Item(itemB.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationDelete))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStatePending))
+	summary, exists = ctx.graph.Item(itemExt.name).Get()
+	g.Expect(exists).To(BeFalse())
+}
+
+// Items: A, B, C
+// Dependencies: A->B->C
+// Scenario: some Create/Modify/Delete operations fail
+func TestFailures(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx = newTestCtx(depgraph.NewDepGraph(log))
+
+	itemA := mockItem{
+		name:     "A",
+		itemType: "type1",
+		modifiableAttrs: mockItemAttrs{
+			// simulate reference to a dependency
+			strAttr: "B",
+		},
+	}
+	itemB := mockItem{
+		name:     "B",
+		itemType: "type1",
+		modifiableAttrs: mockItemAttrs{
+			// simulate reference to a dependency
+			strAttr: "C",
+		},
+	}
+	itemC := mockItem{
+		name:     "C",
+		itemType: "type2",
+	}
+
+	g.Expect(ctx.addConfigurator("type1", depFromStrAttr)).To(Succeed())
+	g.Expect(ctx.addConfigurator("type2", nil)).To(Succeed())
+
+	// 1. itemB will fail to be created
+	itemB.failToCreate = true
+	itemB.failToDelete = true // prepare for scenario 4.
+	ctx.graph.Item(itemA.name).Put(itemA)
+	ctx.graph.Item(itemB.name).Put(itemB)
+	ctx.graph.Item(itemC.name).Put(itemC)
+	g.Expect(ctx.syncGraph()).ToNot(Succeed())
+	g.Expect(itemA).ToNot(BeCreated())
+	g.Expect(itemB).To(BeCreated().WithError("failed to create"))
+	g.Expect(itemC).To(BeCreated().Before(itemB))
+	g.Expect(ctx.executedOps()).To(HaveLen(2))
+
+	summary, exists := ctx.graph.Item(itemA.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationUnknown))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStatePending))
+	summary, exists = ctx.graph.Item(itemB.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(MatchError("failed to create"))
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateFailure))
+	summary, exists = ctx.graph.Item(itemC.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+
+	// 2. Next attempt to create itemB is successful
+	itemB.failToCreate = false
+	itemB.modifiableAttrs.boolAttr = true
+	ctx.graph.Item(itemB.name).Put(itemB)
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemA).To(BeCreated().After(itemB))
+	g.Expect(itemB).To(BeCreated())
+	g.Expect(ctx.executedOps()).To(HaveLen(2))
+
+	summary, exists = ctx.graph.Item(itemA.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+	summary, exists = ctx.graph.Item(itemB.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+	summary, exists = ctx.graph.Item(itemC.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+
+	// 3. Simulate failure to modify C
+	itemC.failToCreate = true
+	itemC.modifiableAttrs.strAttr = "modified"
+	ctx.graph.Item(itemC.name).Put(itemC)
+
+	g.Expect(ctx.syncGraph()).ToNot(Succeed())
+	g.Expect(itemC).To(BeModified().WithError("failed to modify"))
+	g.Expect(ctx.executedOps()).To(HaveLen(1))
+
+	summary, exists = ctx.graph.Item(itemA.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+	summary, exists = ctx.graph.Item(itemB.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationCreate))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateCreated))
+	summary, exists = ctx.graph.Item(itemC.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationModify))
+	g.Expect(summary.LastError).To(MatchError("failed to modify"))
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateFailure))
+
+	// 4. Simulate failure to re-create itemB (delete fails)
+	itemB.staticAttrs.strAttr = "modified"
+	ctx.graph.Item(itemB.name).Put(itemB)
+
+	g.Expect(ctx.syncGraph()).ToNot(Succeed())
+	g.Expect(itemA).To(BeDeleted().Before(itemB))
+	g.Expect(itemB).To(BeDeleted().WithError("failed to delete"))
+	g.Expect(ctx.executedOps()).To(HaveLen(2))
+
+	summary, exists = ctx.graph.Item(itemA.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationDelete))
+	g.Expect(summary.LastError).To(BeNil())
+	g.Expect(summary.State).To(Equal(depgraph.ItemStatePending))
+	summary, exists = ctx.graph.Item(itemB.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationDelete))
+	g.Expect(summary.LastError).To(MatchError("failed to delete"))
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateFailure))
+	summary, exists = ctx.graph.Item(itemC.name).Get()
+	g.Expect(exists).To(BeTrue())
+	g.Expect(summary.LastOp).To(Equal(depgraph.OperationModify))
+	g.Expect(summary.LastError).To(MatchError("failed to modify"))
+	g.Expect(summary.State).To(Equal(depgraph.ItemStateFailure))
+}
+
+// Items (clustered): [A, B, [C, D]]
+// Dependencies: C->A, D->B
+func TestDOTRendering(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx = newTestCtx(depgraph.NewDepGraph(log))
+
+	itemA := mockItem{
+		name:     "A",
+		itemType: "type1",
+	}
+	itemB := mockItem{
+		name:     "B",
+		itemType: "type1",
+	}
+	itemC := mockItem{
+		name:     "C",
+		itemType: "type2",
+		modifiableAttrs: mockItemAttrs{
+			// simulate reference to a dependency
+			strAttr: "A",
+		},
+	}
+	itemD := mockItem{
+		name:     "D",
+		itemType: "type2",
+		modifiableAttrs: mockItemAttrs{
+			// simulate reference to a dependency
+			strAttr: "B",
+		},
+	}
+
+	g.Expect(ctx.addConfigurator("type1", nil)).To(Succeed())
+	g.Expect(ctx.addConfigurator("type2", depFromStrAttr)).To(Succeed())
+
+	// 1. Create clusters
+	nestedCluster := depgraph.Cluster{
+		Name:        "nested",
+		Description: "Nested cluster",
+		Items:       []depgraph.Item{itemC, itemD},
+		SubClusters: nil,
+	}
+	cluster := depgraph.Cluster{
+		Name:        "with-nested",
+		Description: "cluster with itemA, itemB and one nested cluster",
+		Items:       []depgraph.Item{itemA, itemB},
+		SubClusters: []depgraph.Cluster{nestedCluster},
+	}
+	ctx.graph.Cluster(cluster.Name).Put(cluster)
+	g.Expect(ctx.syncGraph()).To(Succeed())
+
+	// 2. Render DOT description of the graph
+	dot, err := ctx.graph.RenderDOT()
+	g.Expect(err).To(BeNil())
+	g.Expect(dot).ToNot(BeEmpty())
+	g.Expect(dot).To(ContainSubstring("subgraph cluster_with_nested {"))
+	g.Expect(dot).To(ContainSubstring("subgraph cluster_nested {"))
+	g.Expect(dot).To(ContainSubstring("C -> A"))
+	g.Expect(dot).To(ContainSubstring("D -> B"))
+	g.Expect(dot).To(ContainSubstring("tooltip = \"item A with attrs: {0  false []}; {0  false []}\""))
+	g.Expect(dot).To(ContainSubstring("tooltip = \"item B with attrs: {0  false []}; {0  false []}\""))
+	g.Expect(dot).To(ContainSubstring("tooltip = \"item C with attrs: {0 A false []}; {0  false []}\""))
+	g.Expect(dot).To(ContainSubstring("tooltip = \"item D with attrs: {0 B false []}; {0  false []}\""))
+	g.Expect(dot).To(ContainSubstring("tooltip = \"Nested cluster\""))
+	g.Expect(dot).To(ContainSubstring("tooltip = \"cluster with itemA, itemB and one nested cluster\""))
+	g.Expect(strings.Count(dot, "{")).To(Equal(strings.Count(dot, "}")))
+
+	// 3. Even unmet dependencies should be shown in the DOT rendering
+	ctx.graph.Item(itemA.name).Del()
+	g.Expect(ctx.syncGraph()).To(Succeed())
+	g.Expect(itemA).To(BeDeleted())
+	g.Expect(itemC).To(BeDeleted().Before(itemA))
+	g.Expect(ctx.executedOps()).To(HaveLen(2))
+
+	dot, err = ctx.graph.RenderDOT()
+	g.Expect(err).To(BeNil())
+	g.Expect(dot).ToNot(BeEmpty())
+	g.Expect(dot).To(ContainSubstring("subgraph cluster_with_nested {"))
+	g.Expect(dot).To(ContainSubstring("subgraph cluster_nested {"))
+	g.Expect(dot).To(ContainSubstring("C -> A"))
+	g.Expect(dot).To(ContainSubstring("D -> B"))
+	g.Expect(dot).To(ContainSubstring("tooltip = \"<missing>\""))
+	g.Expect(dot).To(ContainSubstring("tooltip = \"item B with attrs: {0  false []}; {0  false []}\""))
+	g.Expect(dot).To(ContainSubstring("tooltip = \"item C with attrs: {0 A false []}; {0  false []}\""))
+	g.Expect(dot).To(ContainSubstring("tooltip = \"item D with attrs: {0 B false []}; {0  false []}\""))
+	g.Expect(dot).To(ContainSubstring("tooltip = \"Nested cluster\""))
+	g.Expect(dot).To(ContainSubstring("tooltip = \"cluster with itemA, itemB and one nested cluster\""))
+	g.Expect(strings.Count(dot, "{")).To(Equal(strings.Count(dot, "}")))
+}
+
+func BenchmarkDepGraph100(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		perfTest(100)
+	}
+}
+
+func BenchmarkDepGraph1000(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		perfTest(1000)
+	}
+}
+
+func BenchmarkDepGraph10000(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		perfTest(10000)
+	}
+}
+
+func BenchmarkDepGraph100000(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		perfTest(100000)
+	}
+}
+
+// Perf test proves that the DepGraph.Sync() complexity is linear with respect
+// to the number of nodes. Actually, it is O(V+E), but each node has only
+// a constant number of edges in this benchmark, reflecting a realistic
+// use-case.
+func perfTest(numOfItems int) {
+	ctx = newTestCtx(depgraph.NewDepGraph(log))
+	ctx.addConfigurator("item-type", depFromSliceAttr)
+	const numOfDeps = 10
+	for i := 0; i < numOfItems; i++ {
+		item := mockItem{
+			name:     strconv.Itoa(i),
+			itemType: "item-type",
+		}
+		item.modifiableAttrs.sliceAttr = make([]string, 0, numOfDeps)
+		for j := i + 1; j < numOfItems && j <= i+numOfDeps; j++ {
+			item.modifiableAttrs.sliceAttr = append(
+				item.modifiableAttrs.sliceAttr, strconv.Itoa(j))
+		}
+		ctx.graph.Item(item.name).Put(item)
+	}
+	ctx.syncGraph()
+}


### PR DESCRIPTION
This commit adds package "depgraph" under EVE/pillar implementing a [dependency
graph](https://en.wikipedia.org/wiki/Dependency_graph). It will be used in EVE to generically solve the problem of reconciliation
beetween the actual/current (configuration) state and the latest intended/desired
state. Everytime the desired state changes, a certain sequence of Create, Modify
and Delete operations has to be scheduled and executed to update the current
state. The order of operations often matters and it has to respect all dependencies
that exist between configuration items.
The plan is to first refactor NIM and use dependency graph for configuration
items that device networks are built with.
Based on how NIM refactoring goes, depgraph could be used for zedrouter next.

For more detailed reasoning and motivation behind depgraph, please refer to
the proposal presented on the [LF Edge wiki](https://wiki.lfedge.org/display/EVE/Dependency+graph+for+configuration+items).

Signed-off-by: Milan Lenco <milan@zededa.com>